### PR TITLE
Add support for publishing of SignWriting PDF bibles.

### DIFF
--- a/BibleFileLib/BibleFileLib.csproj
+++ b/BibleFileLib/BibleFileLib.csproj
@@ -91,6 +91,7 @@
     <Reference Include="System.Data">
       <Name>System.Data</Name>
     </Reference>
+    <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Windows.Forms">

--- a/BibleFileLib/Usfx2XeTeX.cs
+++ b/BibleFileLib/Usfx2XeTeX.cs
@@ -159,6 +159,83 @@ namespace WordSend
         }
 
         /// <summary>
+        /// Translate a ((...)) string into a set of SignWriting ASL fingerspelling
+        /// </summary>
+        /// <param name="header">The string which we are potentially translating.</param>
+        private string FingerSpell(string header)
+        {
+            // TODO: Figure how to get surrogate pairs/placement to transmit and remove this function
+            string result="";
+            while(header.Length>0)
+            {
+                if(header.IndexOf("((") == -1)
+                {
+                    result += header;
+                    header = "";
+                }
+                else if(header.IndexOf("))") == -1)
+                {
+                    result += header;
+                    header = "";
+                }
+                else if(header.IndexOf("))") < header.IndexOf("(("))
+                {
+                    result += header.Substring(header.IndexOf("))")+2);
+                    header = header.Substring(header.IndexOf("))")+2);
+                }
+                else if(header.IndexOf("((") == 0)
+                {
+                    header = header.Substring(2);
+                    while(header.IndexOf("))") > 0)
+                    {
+                        if(header[0]=='0') { result+="\\char\"F2C5F\\,"; header=header.Substring(1); }
+                        if(header[0]=='1') { result+="\\char\"F000F\\,"; header=header.Substring(1); }
+                        if(header[0]=='2') { result+="\\char\"F054F\\,"; header=header.Substring(1); }
+                        if(header[0]=='3') { result+="\\char\"F0B4F\\,"; header=header.Substring(1); }
+                        if(header[0]=='4') { result+="\\char\"F198F\\,"; header=header.Substring(1); }
+                        if(header[0]=='5') { result+="\\char\"F1C8F\\,"; header=header.Substring(1); }
+                        if(header[0]=='6') { result+="\\char\"F32CF\\,"; header=header.Substring(1); }
+                        if(header[0]=='7') { result+="\\char\"F3E0F\\,"; header=header.Substring(1); }
+                        if(header[0]=='8') { result+="\\char\"F464F\\,"; header=header.Substring(1); }
+                        if(header[0]=='9') { result+="\\char\"F4D6F\\,"; header=header.Substring(1); }
+                        if(header[0]=='A' || header[0]=='a') { result+="\\raisebox{\\FontSize/10}{\\char\"F5CCF}\\,"; header=header.Substring(1); }
+                        if(header[0]=='B' || header[0]=='b') { result+="\\char\"F1ACF\\,"; header=header.Substring(1); }
+                        if(header[0]=='C' || header[0]=='c') { result+="\\raisebox{\\FontSize/20}{\\char\"F290F}\\,"; header=header.Substring(1); }
+                        if(header[0]=='D' || header[0]=='d') { result+="\\char\"F007F\\,"; header=header.Substring(1); }
+                        if(header[0]=='E' || header[0]=='e') { result+="\\char\"F1BEF\\,"; header=header.Substring(1); }
+                        if(header[0]=='F' || header[0]=='f') { result+="\\char\"F4D6F\\,"; header=header.Substring(1); }
+                        if(header[0]=='G' || header[0]=='g') { result+="\\raisebox{\\FontSize/3}{\\char\"F5A0F}\\,"; header=header.Substring(1); }
+                        if(header[0]=='H' || header[0]=='h') { result+="\\char\"F07E9\\,"; header=header.Substring(1); }
+                        if(header[0]=='I' || header[0]=='i') { result+="\\char\"F36EF\\,"; header=header.Substring(1); }
+                        if(header[0]=='J' || header[0]=='j') { result+="\\raisebox{\\FontSize/3}{\\char\"F9CC8}\\char\"F36EF\\,"; header=header.Substring(1); }
+                        if(header[0]=='K' || header[0]=='k') { result+="\\char\"F182F\\,"; header=header.Substring(1); }
+                        if(header[0]=='L' || header[0]=='l') { result+="\\char\"F52AF\\,"; header=header.Substring(1); }
+                        if(header[0]=='M' || header[0]=='m') { result+="\\char\"F350F\\,"; header=header.Substring(1); }
+                        if(header[0]=='N' || header[0]=='n') { result+="\\raisebox{\\FontSize/6}{\\char\"F098F}\\,"; header=header.Substring(1); }
+                        if(header[0]=='O' || header[0]=='o') { result+="\\char\"F2C6F\\,"; header=header.Substring(1); }
+                        if(header[0]=='P' || header[0]=='p') { result+="\\raisebox{\\FontSize/3}{\\char\"F1830}\\,"; header=header.Substring(1); }
+                        if(header[0]=='Q' || header[0]=='q') { result+="\\char\"F5A30\\,"; header=header.Substring(1); }
+                        if(header[0]=='R' || header[0]=='r') { result+="\\raisebox{\\FontSize/20}{\\char\"F09EF}\\,"; header=header.Substring(1); }
+                        if(header[0]=='S' || header[0]=='s') { result+="\\char\"F614F\\,"; header=header.Substring(1); }
+                        if(header[0]=='T' || header[0]=='t') { result+="\\char\"F5E4F\\,"; header=header.Substring(1); }
+                        if(header[0]=='U' || header[0]=='u') { result+="\\char\"F080F\\,"; header=header.Substring(1); }
+                        if(header[0]=='V' || header[0]=='v') { result+="\\char\"F056F\\,"; header=header.Substring(1); }
+                        if(header[0]=='W' || header[0]=='w') { result+="\\char\"F32CF\\,"; header=header.Substring(1); }
+                        if(header[0]=='X' || header[0]=='x') { result+="\\char\"F026F\\,"; header=header.Substring(1); }
+                        if(header[0]=='Y' || header[0]=='y') { result+="\\char\"F39EF\\,"; header=header.Substring(1); }
+                        if(header[0]=='Z' || header[0]=='z') { result+="\\char\"F79E5\\char\"F002F\\,"; header=header.Substring(1); }
+                    }
+                }
+                else
+                {
+                    result += header.Substring(header.IndexOf("(("));
+                    header = header.Substring(header.IndexOf("(("));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
         /// In this overridden version, we actually open a TeX file for the whole book, not just a chapter.
         /// </summary>
         /// <param name="fileName">Name of file to open if other than a Bible book.</param>
@@ -207,6 +284,9 @@ namespace WordSend
             // TODO: refactor to use htm instead of texFile throughout OR get the htm references out of the core function in Usfx2HtmlConverter.cs
             htm = texFile = new StreamWriter(currentFileName, false, Encoding.UTF8);
             
+            // TODO: figure out how to get surrogate pairs to transmit and get rid of this
+            runningHeader = FingerSpell(runningHeader);
+
             if (projectOptions.textDir == "rtl")
                 texFile.WriteLine(@"\setRTL");
             else if (texDir == "ltr")
@@ -335,11 +415,13 @@ namespace WordSend
                 .Replace("&", @"\&").Replace("_", @"\_").Replace(LEFTBRACE, @"$\{$").Replace("’”", "’\u00A0”")
                 .Replace("^", "\u2303")    // Replace circumflex with look-alike up arrowhead to avoid TeX math command behavior and old style diacritic behavior
                 .Replace(RIGHTBRACE, @"$\}$").Replace("”’", "”\u00A0’").Replace("‘“", "‘\u00A0“").Replace("“‘", "“\u00A0‘").Replace("ʻ", "{ʻ}")
-                // TODO get rid of it when the translation is complete
+                // TODO: get rid of it when the translation is complete
                 // I am perfectly aware that this is a horrible hack.
                 // This is an attempt to bypass USFX and, rightfully so, USFX does not have a "output this if the output format is .." tag.
                 .Replace(@"\$\backslash\$begin$\{$signline$\}$",@"\signline{")
                 .Replace(@"\$\backslash\$end$\{$signline$\}$","}");
+            // TODO: figure out how to get surrogate pairs to transmit and get rid of this
+            text = FingerSpell(text);
             if (!ignore)
             {
                 if (eatSpace)
@@ -1419,14 +1501,15 @@ For other uses, please contact the respective copyright owners.</p>
             else if (projectOptions.textDir == "ttb-ltr")
             {
                 //TODO: Make this a generic ttb-ltr instead of SignWriting specific
+                //TODO: Use the actual size (6pt) instead of equivalent (12pt) for SignWriting
                 fileHelper.CopyFile(FindInputFile("haiolasw.tex"), Path.Combine(texDir, "haiolasw.tex"));
-                WriteXeTeXHeader(Path.Combine(texDir, "12ptsw.tex"), "8.5in", "11in", "0.75in", "0.75in", "1in", "1in", "11.0pt", "12pt", 12.0, 2, false, true, true);
-                WriteXeTeXHeader(Path.Combine(texDir, "12pta4sw.tex"), "210mm", "297mm", "25mm", "25mm", "30mm", "30mm", "11.0pt", "12pt", 12.0, 2, false, true, true);
-                WriteXeTeXHeader(Path.Combine(texDir, "12pta5sw.tex"), "148mm", "210mm", "25mm", "25mm", "25mm", "25mm", "11.0pt", "12pt", 12.0, 1, false, true, true);
-                WriteXeTeXHeader(Path.Combine(texDir, "printsw.tex"), "6in", "9in", "0.35in", "0.35in", "0.5in", "0.5in", "11.0pt", "9pt", 9.0, 1, false, true, false);
-                WriteXeTeXHeader(Path.Combine(texDir, "booksw.tex"), "152.4mm", "228.6mm", "10mm", "10mm", "23mm", "23mm", "11.0pt", "6pt", 8.0, 2, false, true, false);
-                WriteXeTeXHeader(Path.Combine(texDir, "ntsw.tex"), "120mm", "200mm", "7.5mm", "7.5mm", "10mm", "10mm", "11.0pt", "6pt", 9.0, 2, false, true, false);
-                WriteXeTeXHeader(Path.Combine(texDir, "ntpsw.tex"), "120mm", "200mm", "7.5mm", "7.5mm", "10mm", "10mm", "11.0pt", "6pt", 8.0, 2, false, true, false);
+                WriteXeTeXHeader(Path.Combine(texDir, "12ptsw.tex"), "8.5in", "11in", "0.75in", "0.75in", "1in", "1in", "11.0pt", "12pt", 6.0, 2, false, true, true);
+                WriteXeTeXHeader(Path.Combine(texDir, "12pta4sw.tex"), "210mm", "297mm", "25mm", "25mm", "30mm", "30mm", "11.0pt", "12pt", 6.0, 2, false, true, true);
+                WriteXeTeXHeader(Path.Combine(texDir, "12pta5sw.tex"), "148mm", "210mm", "25mm", "25mm", "25mm", "25mm", "11.0pt", "12pt", 6.0, 1, false, true, true);
+                WriteXeTeXHeader(Path.Combine(texDir, "printsw.tex"), "6in", "9in", "0.35in", "0.35in", "0.5in", "0.5in", "11.0pt", "9pt", 4.5, 1, false, true, false);
+                WriteXeTeXHeader(Path.Combine(texDir, "booksw.tex"), "152.4mm", "228.6mm", "10mm", "10mm", "23mm", "23mm", "11.0pt", "6pt", 4.0, 2, false, true, false);
+                WriteXeTeXHeader(Path.Combine(texDir, "ntsw.tex"), "120mm", "200mm", "7.5mm", "7.5mm", "10mm", "10mm", "11.0pt", "6pt", 4.5, 2, false, true, false);
+                WriteXeTeXHeader(Path.Combine(texDir, "ntpsw.tex"), "120mm", "200mm", "7.5mm", "7.5mm", "10mm", "10mm", "11.0pt", "6pt", 4.0, 2, false, true, false);
             }
             else
             {

--- a/BibleFileLib/Usfx2XeTeX.cs
+++ b/BibleFileLib/Usfx2XeTeX.cs
@@ -189,41 +189,42 @@ namespace WordSend
                     while(header.IndexOf("))") > 0)
                     {
                         if(header[0]=='0') { result+="\\char\"F2C5F\\,"; header=header.Substring(1); }
-                        if(header[0]=='1') { result+="\\char\"F000F\\,"; header=header.Substring(1); }
-                        if(header[0]=='2') { result+="\\char\"F054F\\,"; header=header.Substring(1); }
-                        if(header[0]=='3') { result+="\\char\"F0B4F\\,"; header=header.Substring(1); }
-                        if(header[0]=='4') { result+="\\char\"F198F\\,"; header=header.Substring(1); }
-                        if(header[0]=='5') { result+="\\char\"F1C8F\\,"; header=header.Substring(1); }
-                        if(header[0]=='6') { result+="\\char\"F32CF\\,"; header=header.Substring(1); }
-                        if(header[0]=='7') { result+="\\char\"F3E0F\\,"; header=header.Substring(1); }
-                        if(header[0]=='8') { result+="\\char\"F464F\\,"; header=header.Substring(1); }
-                        if(header[0]=='9') { result+="\\char\"F4D6F\\,"; header=header.Substring(1); }
-                        if(header[0]=='A' || header[0]=='a') { result+="\\raisebox{\\FontSize/10}{\\char\"F5CCF}\\,"; header=header.Substring(1); }
-                        if(header[0]=='B' || header[0]=='b') { result+="\\char\"F1ACF\\,"; header=header.Substring(1); }
-                        if(header[0]=='C' || header[0]=='c') { result+="\\raisebox{\\FontSize/20}{\\char\"F290F}\\,"; header=header.Substring(1); }
-                        if(header[0]=='D' || header[0]=='d') { result+="\\char\"F007F\\,"; header=header.Substring(1); }
-                        if(header[0]=='E' || header[0]=='e') { result+="\\char\"F1BEF\\,"; header=header.Substring(1); }
-                        if(header[0]=='F' || header[0]=='f') { result+="\\char\"F4D6F\\,"; header=header.Substring(1); }
-                        if(header[0]=='G' || header[0]=='g') { result+="\\raisebox{\\FontSize/3}{\\char\"F5A0F}\\,"; header=header.Substring(1); }
-                        if(header[0]=='H' || header[0]=='h') { result+="\\char\"F07E9\\,"; header=header.Substring(1); }
-                        if(header[0]=='I' || header[0]=='i') { result+="\\char\"F36EF\\,"; header=header.Substring(1); }
-                        if(header[0]=='J' || header[0]=='j') { result+="\\raisebox{\\FontSize/3}{\\char\"F9CC8}\\char\"F36EF\\,"; header=header.Substring(1); }
-                        if(header[0]=='K' || header[0]=='k') { result+="\\char\"F182F\\,"; header=header.Substring(1); }
-                        if(header[0]=='L' || header[0]=='l') { result+="\\char\"F52AF\\,"; header=header.Substring(1); }
-                        if(header[0]=='M' || header[0]=='m') { result+="\\char\"F350F\\,"; header=header.Substring(1); }
-                        if(header[0]=='N' || header[0]=='n') { result+="\\raisebox{\\FontSize/6}{\\char\"F098F}\\,"; header=header.Substring(1); }
-                        if(header[0]=='O' || header[0]=='o') { result+="\\char\"F2C6F\\,"; header=header.Substring(1); }
-                        if(header[0]=='P' || header[0]=='p') { result+="\\raisebox{\\FontSize/3}{\\char\"F1830}\\,"; header=header.Substring(1); }
-                        if(header[0]=='Q' || header[0]=='q') { result+="\\char\"F5A30\\,"; header=header.Substring(1); }
-                        if(header[0]=='R' || header[0]=='r') { result+="\\raisebox{\\FontSize/20}{\\char\"F09EF}\\,"; header=header.Substring(1); }
-                        if(header[0]=='S' || header[0]=='s') { result+="\\char\"F614F\\,"; header=header.Substring(1); }
-                        if(header[0]=='T' || header[0]=='t') { result+="\\char\"F5E4F\\,"; header=header.Substring(1); }
-                        if(header[0]=='U' || header[0]=='u') { result+="\\char\"F080F\\,"; header=header.Substring(1); }
-                        if(header[0]=='V' || header[0]=='v') { result+="\\char\"F056F\\,"; header=header.Substring(1); }
-                        if(header[0]=='W' || header[0]=='w') { result+="\\char\"F32CF\\,"; header=header.Substring(1); }
-                        if(header[0]=='X' || header[0]=='x') { result+="\\char\"F026F\\,"; header=header.Substring(1); }
-                        if(header[0]=='Y' || header[0]=='y') { result+="\\char\"F39EF\\,"; header=header.Substring(1); }
-                        if(header[0]=='Z' || header[0]=='z') { result+="\\char\"F79E5\\char\"F002F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='1') { result+="\\char\"F000F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='2') { result+="\\char\"F054F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='3') { result+="\\char\"F0B4F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='4') { result+="\\char\"F198F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='5') { result+="\\char\"F1C8F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='6') { result+="\\char\"F32CF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='7') { result+="\\char\"F3E0F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='8') { result+="\\char\"F464F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='9') { result+="\\char\"F4D6F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='A' || header[0]=='a') { result+="\\raisebox{\\FontSize/10}{\\char\"F5CCF}\\,"; header=header.Substring(1); }
+                        else if(header[0]=='B' || header[0]=='b') { result+="\\char\"F1ACF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='C' || header[0]=='c') { result+="\\raisebox{\\FontSize/20}{\\char\"F290F}\\,"; header=header.Substring(1); }
+                        else if(header[0]=='D' || header[0]=='d') { result+="\\char\"F007F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='E' || header[0]=='e') { result+="\\char\"F1BEF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='F' || header[0]=='f') { result+="\\char\"F4D6F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='G' || header[0]=='g') { result+="\\raisebox{\\FontSize/3}{\\char\"F5A0F}\\,"; header=header.Substring(1); }
+                        else if(header[0]=='H' || header[0]=='h') { result+="\\char\"F07E9\\,"; header=header.Substring(1); }
+                        else if(header[0]=='I' || header[0]=='i') { result+="\\char\"F36EF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='J' || header[0]=='j') { result+="\\raisebox{\\FontSize/3}{\\char\"F9CC8}\\char\"F36EF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='K' || header[0]=='k') { result+="\\char\"F182F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='L' || header[0]=='l') { result+="\\char\"F52AF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='M' || header[0]=='m') { result+="\\char\"F350F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='N' || header[0]=='n') { result+="\\raisebox{\\FontSize/6}{\\char\"F098F}\\,"; header=header.Substring(1); }
+                        else if(header[0]=='O' || header[0]=='o') { result+="\\char\"F2C6F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='P' || header[0]=='p') { result+="\\raisebox{\\FontSize/3}{\\char\"F1830}\\,"; header=header.Substring(1); }
+                        else if(header[0]=='Q' || header[0]=='q') { result+="\\char\"F5A30\\,"; header=header.Substring(1); }
+                        else if(header[0]=='R' || header[0]=='r') { result+="\\raisebox{\\FontSize/20}{\\char\"F09EF}\\,"; header=header.Substring(1); }
+                        else if(header[0]=='S' || header[0]=='s') { result+="\\char\"F614F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='T' || header[0]=='t') { result+="\\char\"F5E4F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='U' || header[0]=='u') { result+="\\char\"F080F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='V' || header[0]=='v') { result+="\\char\"F056F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='W' || header[0]=='w') { result+="\\char\"F32CF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='X' || header[0]=='x') { result+="\\char\"F026F\\,"; header=header.Substring(1); }
+                        else if(header[0]=='Y' || header[0]=='y') { result+="\\char\"F39EF\\,"; header=header.Substring(1); }
+                        else if(header[0]=='Z' || header[0]=='z') { result+="\\char\"F79E5\\char\"F002F\\,"; header=header.Substring(1); }
+                        else { result += header[0]; header=header.Substring(1); }
                     }
                 }
                 else

--- a/BibleFileLib/Usfx2XeTeX.cs
+++ b/BibleFileLib/Usfx2XeTeX.cs
@@ -334,7 +334,12 @@ namespace WordSend
             text = text.Replace(@"\", @"$\backslash$").Replace("$", @"\$").Replace("#", @"\#").Replace("%", @"\%")
                 .Replace("&", @"\&").Replace("_", @"\_").Replace(LEFTBRACE, @"$\{$").Replace("’”", "’\u00A0”")
                 .Replace("^", "\u2303")    // Replace circumflex with look-alike up arrowhead to avoid TeX math command behavior and old style diacritic behavior
-                .Replace(RIGHTBRACE, @"$\}$").Replace("”’", "”\u00A0’").Replace("‘“", "‘\u00A0“").Replace("“‘", "“\u00A0‘").Replace("ʻ", "{ʻ}");
+                .Replace(RIGHTBRACE, @"$\}$").Replace("”’", "”\u00A0’").Replace("‘“", "‘\u00A0“").Replace("“‘", "“\u00A0‘").Replace("ʻ", "{ʻ}")
+                // TODO get rid of it when the translation is complete
+                // I am perfectly aware that this is a horrible hack.
+                // This is an attempt to bypass USFX and, rightfully so, USFX does not have a "output this if the output format is .." tag.
+                .Replace(@"\$\backslash\$begin$\{$signline$\}$",@"\signline{")
+                .Replace(@"\$\backslash\$end$\{$signline$\}$","}");
             if (!ignore)
             {
                 if (eatSpace)

--- a/BibleFileLib/haiola_options.cs
+++ b/BibleFileLib/haiola_options.cs
@@ -566,7 +566,7 @@ namespace WordSend
 
         public string script
         {
-            get { return ini.ReadString("script", "Latin"); }
+            get { return ini.ReadString("script", "Latn-Latin"); }
             set { ini.WriteString("script", value); }
         }
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# haiola
+
+This particular fork of haiola is to add support for publication of pdf bibles in SignWriting.
+
+For anything outside of that you should probably visit https://haiola.org/

--- a/fswtotex/Program.cs
+++ b/fswtotex/Program.cs
@@ -1,0 +1,1588 @@
+/*
+    Regarding license, this code (and I say nothing about anything outside of this code)
+    is licensed by "The Unlicense".
+
+    You may use for: private use, commercial use, modifiy, and distribute.
+
+    You may not expect: liability, nor warranty.
+
+    This is the same license as the source material:
+        https://github.com/dazitzel/SignWritingLaTeX
+*/
+using System;
+using System.IO;
+
+/*
+    This parser works with as state machines within state machines.
+
+    There is also a general error state which says that we failed in our matching and need
+    to spit out what we have saved so far.
+
+    Our outer state machine has the following states:
+        Start       -- the obligatory starting state
+        Prefix      -- processing the temporal prefix (can be missing)
+        Visual      -- processing the visual layout of the sign (required)
+        Punctuation -- processing a punctuation sign
+        End         -- Time to spit out what we have
+
+    The prefix state machine has the following states:
+        Start       -- the obligatory starting state
+        Symbol      -- processing a base symbol
+        End         -- If we used this state machine, time for the outer state machine to move to the next state
+
+    The visual state machine has the following states:
+        Start       -- the obligatory starting state
+        Size        -- processing the size of the word
+        Symbol      -- processing a base symbol
+        Placement   -- processing the placement of the symbol
+        End         -- Time for the outer state machine to finish
+
+    The Punctuation state machine hase the following states:
+        Symbol      -- processing a base symbol
+        Placement   -- processing the placement of the symbol
+        End         -- Time for the outer state machine to finish
+
+    The Symbol state machine has the following states
+        Start       -- the obligatory starting state
+        FirstDigit  -- the first digit
+        SecondDigit -- the second digit
+        ThirdDigt   -- the third digit
+        Fill        -- the fill
+        Rotation    -- the rotation
+        End         -- Time for the outer state machine to finish
+
+    The Size state machine has the following states:
+        Start       -- the obligatory starting state
+        FirstW      -- the first digit of the width
+        SecondW     -- the second digit of the width
+        ThirdW      -- the third digit of the width
+        x           -- the letter `x'
+        FirstH      -- the first digit of the height
+        SecondH     -- the second digit of the height
+        ThirdH      -- the third digit of the height
+        End         -- Time for the outer state machine to finish
+
+    The Placement state machine is exactly the same as the size state machine
+
+    When this parsing is complete, it spits what may look like rather odd
+    versions of the signs. This is a version specifically adjusted to work
+    with the haiola program and ebible.org in general based on an earlier
+    version done by me in C++.
+*/
+
+namespace fswToTex {
+  class program {
+    const int s_error=-1;
+    const int s_start=0;
+    const int s_prefix=1;
+    const int s_visual=2;
+    const int s_punctuation=3;
+    const int s_size=1;
+    const int s_symbol=2;
+    const int s_placement=3;
+    const int s_first=1;
+    const int s_second=2;
+    const int s_third=3;
+    const int s_fill=4;
+    const int s_rotation=5;
+    const int s_firstw=1;
+    const int s_secondw=2;
+    const int s_thirdw=3;
+    const int s_x=4;
+    const int s_firsth=5;
+    const int s_secondh=6;
+    const int s_thirdh=7;
+    const int s_end=8;
+
+    int state      =s_start;
+    int substate   =s_start;
+    int subsubstate=s_start;
+
+    /*
+    Now we come to reading.
+
+    If we want to be able to read from a wide variety of files, then we
+    have to be ready for all the different encodings and be able to convert
+    each of them into utf-32.
+
+    We will begin here with a set of functions to read a character of a
+    given type. Unknown or undetermined as of yet and utf8/=16/32/le/be. We
+    will then have a set of functions to convert to utf32(internal version)
+    from all the other types of characters.
+
+    Even though these are technically characters, because we are dealing
+    with SignWriting characters which are outside of plane-0 we are going
+    to pass them around as if they are unsigned integers anyway.
+    */
+
+    enum theTextFormat
+    {
+      unknown, utf8, utf16le, utf16be, utf32le, utf32be
+    };
+    theTextFormat textFormat = theTextFormat.unknown;
+
+    byte[] charBuff = {0, 0, 0, 0};
+    int charBuffSize = 0;
+    uint getCharUnknown(FileStream fileIn)
+    {
+      uint result=0;
+      // feff is the byte order
+      // In each format, this can serve as a key
+      // utf  8    ef bb bf
+      // utf 16 le ff fe
+      // utf 16 be fe ff
+      // utf 32 le ff fe 00 00
+      // utf 32 be 00 00 fe ff
+      // So if we are unknown then we look for those,
+      // and if we don't see any of them we default to utf8
+      if(charBuffSize==0)
+      {
+        for(;charBuffSize<4;charBuffSize++)
+        {
+          charBuff[charBuffSize]=(byte)fileIn.ReadByte();
+        }
+        if(charBuff[0]==0x0  && charBuff[1]==0x0 &&
+           charBuff[2]==0xfe && charBuff[3]==0xff)
+        {
+          textFormat=theTextFormat.utf32be;
+          return getCharUtf32be(fileIn);
+        }
+        else if(charBuff[0]==0xff && charBuff[1]==0xfe &&
+                charBuff[2]==0x0  && charBuff[3]==0x0)
+        {
+          textFormat=theTextFormat.utf32le;
+          return getCharUtf32le(fileIn);
+        }
+        else if(charBuff[0]==0xfe && charBuff[1]==0xff)
+        {
+          textFormat=theTextFormat.utf16be;
+          charBuff[0]=charBuff[2];
+          charBuff[1]=charBuff[3];
+          charBuff[2]=0;
+          charBuff[3]=0;
+          if(utf16beToUtf32(charBuff,ref result)==2)
+          {
+            return result;
+          }
+          charBuff[2]=(byte)fileIn.ReadByte();
+          charBuff[3]=(byte)fileIn.ReadByte();
+          if(utf16beToUtf32(charBuff,ref result)==4)
+          {
+            return result;
+          }
+          throw new System.Exception("Badly formed utf16be string.");
+        }
+        else if(charBuff[0]==0xff && charBuff[1]==0xfe)
+        {
+          textFormat=theTextFormat.utf16le;
+          charBuff[0]=charBuff[2];
+          charBuff[1]=charBuff[3];
+          charBuff[2]=0;
+          charBuff[3]=0;
+          if(utf16leToUtf32(charBuff,ref result)==2)
+          {
+            return result;
+          }
+          charBuff[2]=(byte)fileIn.ReadByte();
+          charBuff[3]=(byte)fileIn.ReadByte();
+          if(utf16leToUtf32(charBuff,ref result)==4)
+          {
+            return result;
+          }
+          throw new System.Exception("Badly formed ut16le string.");
+        }
+        else if(charBuff[0]==0xef && charBuff[1]==0xbb &&
+                charBuff[2]==0xbf)
+        {
+          textFormat=theTextFormat.utf8;
+          charBuff[0]=charBuff[3];
+          charBuff[1]=0;
+          charBuff[2]=0;
+          charBuff[3]=0;
+          if(utf8ToUtf32(charBuff,ref result)==1)
+          {
+            return result;
+          }
+          charBuff[1]=(byte)fileIn.ReadByte();
+          if(utf8ToUtf32(charBuff,ref result)==2)
+          {
+            return result;
+          }
+          charBuff[2]=(byte)fileIn.ReadByte();
+          if(utf8ToUtf32(charBuff,ref result)==3)
+          {
+            return result;
+          }
+          charBuff[3]=(byte)fileIn.ReadByte();
+          if(utf8ToUtf32(charBuff,ref result)==4)
+          {
+            return result;
+          }
+          throw new System.Exception("Badly formed utf8 string.");
+        }
+      }
+      int offset = utf8ToUtf32(charBuff,ref result);
+      while(offset<0 && charBuffSize<4)
+      {
+        charBuff[charBuffSize]=(byte)fileIn.ReadByte();
+        charBuffSize++;
+        offset = utf8ToUtf32(charBuff,ref result);
+      }
+      int i;
+      for(i=0;i<charBuffSize-offset;i++)
+      {
+        charBuff[i]=charBuff[i+offset];
+      }
+      for(;i<charBuffSize;i++)
+      {
+        charBuff[i]=0;
+      }
+      charBuffSize-=offset;
+      if(charBuffSize==0)
+      {
+        textFormat=theTextFormat.utf8;
+      }
+      return result;
+    }
+
+    uint getCharUtf8(FileStream fileIn)
+    {
+      byte[] charBuff={0,0,0,0};
+      int read=0;
+      int size=0;
+      uint result=0;
+      do
+      {
+        read = fileIn.ReadByte();
+        if(read==-1)
+          return 0xffffffff;
+        charBuff[size++]=(byte)read;
+      }
+      while((size<4) && (utf8ToUtf32(charBuff,ref result)!=size));
+      if(utf8ToUtf32(charBuff,ref result)==size)
+      {
+        return result;
+      }
+      throw new System.Exception("Badly formed utf8 string.");
+    }
+
+    uint getCharUtf16le(FileStream fileIn)
+    {
+      byte[] charBuff={0,0,0,0};
+      int read=0;
+      int size=0;
+      uint result=0;
+      do
+      {
+        read = fileIn.ReadByte();
+        if(read==-1)
+          return 0xffffffff;
+        charBuff[size++]=(byte)read;
+        read = fileIn.ReadByte();
+        if(read==-1)
+          return 0xffffffff;
+        charBuff[size++]=(byte)read;
+      }
+      while((size<4) && (utf16leToUtf32(charBuff,ref result)!=size));
+      if(utf16leToUtf32(charBuff,ref result)==size)
+      {
+        return result;
+      }
+      throw new System.Exception("Badly formed utf16le string.");
+    }
+
+    uint getCharUtf16be(FileStream fileIn)
+    {
+      byte[] charBuff={0,0,0,0};
+      int read=0;
+      int size=0;
+      uint result=0;
+      do
+      {
+        read = fileIn.ReadByte();
+        if(read==-1)
+          return 0xffffffff;
+        charBuff[size++]=(byte)read;
+        read = fileIn.ReadByte();
+        if(read==-1)
+          return 0xffffffff;
+        charBuff[size++]=(byte)read;
+      }
+      while((size<4) && (utf16beToUtf32(charBuff,ref result)!=size));
+      if(utf16beToUtf32(charBuff,ref result)==size)
+      {
+        return result;
+      }
+      throw new System.Exception("Badly formed utf16be string.");
+    }
+
+    uint getCharUtf32le(FileStream fileIn)
+    {
+      byte[] charBuff={0,0,0,0};
+      int read=0;
+      int size=0;
+      uint result=0;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      utf32leToUtf32(charBuff,ref result);
+      return result;
+    }
+
+    uint getCharUtf32be(FileStream fileIn)
+    {
+      byte[] charBuff={0,0,0,0};
+      int read=0;
+      int size=0;
+      uint result=0;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      read = fileIn.ReadByte();
+      if(read==-1)
+        return 0xffffffff;
+      charBuff[size++]=(byte)read;
+      utf32beToUtf32(charBuff,ref result);
+      return result;
+    }
+
+    uint getChar(FileStream fileIn)
+    {
+      switch(textFormat)
+      {
+        case theTextFormat.utf8   : return getCharUtf8   (fileIn);
+        case theTextFormat.utf16le: return getCharUtf16le(fileIn);
+        case theTextFormat.utf16be: return getCharUtf16be(fileIn);
+        case theTextFormat.utf32le: return getCharUtf32le(fileIn);
+        case theTextFormat.utf32be: return getCharUtf32be(fileIn);
+        default     : return getCharUnknown(fileIn);
+      }
+    }
+
+    /*
+    We always convert to utf-8 on output since we know that we are
+    outputting a lot of XeLaTeX code with expanded characters of the
+    format ``\char#xxxx''.
+    */
+
+    byte[] utf32ToUtf8(uint c)
+    {
+      byte[] to = {};
+      if(c<0x80)
+      {
+        Array.Resize(ref to, to.Length+1);
+        to[to.Length-1] = (byte)c;
+      }
+      else if(c<0x800)
+      {
+        Array.Resize(ref to, to.Length+2);
+        to[to.Length-2] = (byte)(((c>>6)&0x1f)|0xc0);
+        to[to.Length-1] = (byte)(((c>>0)&0x3f)|0x80);
+      }
+      else if(c<0x10000)
+      {
+        Array.Resize(ref to, to.Length+3);
+        to[to.Length-3] = (byte)(((c>>12)&0xf)|0xe0);
+        to[to.Length-2] = (byte)(((c>>6)&0x3f)|0x80);
+        to[to.Length-1] = (byte)(((c>>0)&0x3f)|0x80);
+      }
+      else
+      {
+        Array.Resize(ref to, to.Length+3);
+        to[to.Length-3] = (byte)(((c>>18)&0x7)|0xf0);
+        to[to.Length-3] = (byte)(((c>>12)&0x3f)|0x80);
+        to[to.Length-3] = (byte)(((c>>6)&0x3f)|0x80);
+        to[to.Length-3] = (byte)(((c>>0)&0x3f)|0x80);
+      }
+      return to;
+    }
+
+    // And now we send it out
+    void sendOut(FileStream fileOut, uint c)
+    {
+      byte[] buffer = utf32ToUtf8(c);
+      foreach(byte b in buffer)
+        fileOut.WriteByte(b);
+    }
+
+    void sendOut(FileStream fileOut, ref uint[] l, uint c)
+    {
+      int i;
+      for(i=0;i<l.Length;i++)
+        sendOut(fileOut,l[i]);
+      sendOut(fileOut,c);
+      Array.Resize(ref l, 0);
+      state=substate=subsubstate=s_start;
+    }
+
+    // Now that we have been using all those ``convert to uft32'', let's define them.
+
+    int utf8ToUtf32(byte[] coming, ref uint going)
+    {
+      // Quick review:
+      //    0xxx xxxx
+      //    110x xxxx  10xx xxxx
+      //    1110 xxxx  10xx xxxx  10xx xxxx
+      //    1111 -xxx  10xx xxxx  10xx xxxx  10xx xxxx
+      if((coming[0]&0xf0)==0xf0)
+      {
+        going=(uint)coming[0]&0x7;
+        for(int i=1;i<4;i++)
+        {
+          if((coming[i]&0xc0)!=0x80)
+            return 0;
+          going<<=6;
+          going|=(uint)(coming[i]&0x3f);
+        }
+        return 4;
+      }
+      if((coming[0]&0xf0)==0xe0)
+      {
+        going=(uint)coming[0]&0xf;
+        for(int i=1;i<3;i++)
+        {
+          if((coming[i]&0xc0)!=0x80)
+            return 0;
+          going<<=6;
+          going|=(uint)(coming[i]&0x3f);
+        }
+        return 3;
+      }
+      if((coming[0]&0xe0)==0xc0)
+      {
+        going=(uint)coming[0]&0x1f;
+        for(int i=1;i<2;i++)
+        {
+          if((coming[i]&0xc0)!=0x80)
+            return 0;
+          going<<=6;
+          going|=(uint)(coming[i]&0x3f);
+        }
+        return 2;
+      }
+      if((coming[0]&0xc0)==0x80)
+      {
+        throw new System.Exception("Malformed utf8 string.");
+      }
+      going=coming[0];
+      return 1;
+    }
+
+    int utf16leToUtf32(byte[] coming, ref uint going)
+    {
+      // Quick review, after accounting for endianess
+      // 0000--d7ff = pass along
+      // d800--d8ff = a following dc00-dfff tells the low 10 bits
+      // dc00--dfff = better be following d800-d8ff
+      // e000--ffff = pass along
+      going=(uint)coming[0]<<0;
+      going|=(uint)coming[1]<<8;
+      if(going<0xd800)
+        return 2;
+      if(going<0xdc00)
+      {
+        if(coming[3]<0xdc || coming[3]>0xdf)
+          return 0;
+        going&=0x3ff;
+        going|=0x400;
+        going<<=10;
+        going|=coming[2];
+        going|=(uint)(coming[3]&0x3)<<8;
+        return 2;
+      }
+      if(going<0xe000)
+        throw new System.Exception("Malformed utf16le string");
+      return 2;
+    }
+
+    int utf16beToUtf32(byte[] coming, ref uint going)
+    {
+      // Quick review, after accounting for endianess
+      // 0000--d7ff = pass along
+      // d800--d8ff = a following dc00-dfff tells the low 10 bits
+      // dc00--dfff = better be following d800-d8ff
+      going=(uint)coming[0]<<8;
+      going|=(uint)coming[1]<<0;
+      if(going<0xd800)
+        return 2;
+      if(going<0xdc00)
+      {
+        if(coming[2]<0xdc || coming[2]>0xdf)
+          return 0;
+        going&=0x3ff;
+        going|=0x400;
+        going<<=10;
+        going|=(uint)(coming[2]&0x3)<<8;
+        going|=(uint)coming[3];
+        return 2;
+      }
+      if(going<0xe000)
+        throw new System.Exception("Malformed utf16le string");
+      return 2;
+    }
+
+    int utf32leToUtf32(byte[] coming, ref uint going)
+    {
+      going=(uint)coming[0]<<0;
+      going|=(uint)coming[1]<<8;
+      going|=(uint)coming[2]<<16;
+      going|=(uint)coming[3]<<24;
+      return 4;
+    }
+
+    int utf32beToUtf32(byte[] coming, ref uint going)
+    {
+      going=(uint)coming[0]<<24;
+      going|=(uint)coming[1]<<16;
+      going|=(uint)coming[2]<<8;
+      going|=(uint)coming[3]<<0;
+      return 4;
+    }
+
+    // A couple more helper functions to keep the code clear
+    void Add(ref uint[] line, uint toAdd)
+    {
+        Array.Resize(ref line, line.Length+1);
+        line[line.Length-1] = toAdd;
+    }
+
+    void stringToByte(string coming, ref byte[] going)
+    {
+      uint tempuint = 0;
+      byte[] tempgoing = {};
+      Array.Resize(ref going, 0);
+      for(int i=0;i<coming.Length;i++)
+      {
+        tempuint=(uint)coming[i];
+        tempgoing = utf32ToUtf8(tempuint);
+        Array.Resize(ref going, going.Length+tempgoing.Length);
+        for(int j=0; j < tempgoing.Length; j++)
+          going[going.Length-tempgoing.Length+j] = tempgoing[j];
+      }
+    }
+
+    // Finally, let's explain and start the program
+
+    int usage()
+    {
+      Console.WriteLine("This is fswtotex.");
+      Console.WriteLine("");
+      Console.WriteLine("This program expects exactly two arguments:");
+      Console.WriteLine("    One input file containing Formal SignWriting embedded in LaTex;");
+      Console.WriteLine("    One output file which will contain TiKz embedded in LaTeX.");
+      Console.WriteLine("");
+      return -1;
+    }
+
+    static int Main(string[] args)
+    {
+      int result=0;
+      //  When we run we expect exactly two arguments:
+      //      the file to read from and;
+      //      The file to write to.
+      //  Once we have that, we let it rip.
+
+      try
+      {
+        program me = new program();
+        if(args.Length!=2)
+        {
+          return me.usage();
+        }
+        if(args[0][0]=='-' || args[1][0]=='-')
+        {
+          return me.usage();
+        }
+        FileStream fileIn = new FileStream(args[0], FileMode.Open, FileAccess.Read);
+        FileStream fileOut= new FileStream(args[1], FileMode.Create, FileAccess.Write);
+        result = me.fswtotex(fileIn, fileOut);
+        string line="";
+        byte[] toSend={};
+        line = "% This file was generated by:\n";
+        me.stringToByte(line, ref toSend);
+        fileOut.Write(toSend,0,toSend.Length);
+        line = "%    fswtotex " + args[0] + " " + args[1] + "\n";
+        me.stringToByte(line, ref toSend);
+        fileOut.Write(toSend,0,toSend.Length);
+        fileOut.Close();
+        fileIn.Close();
+      }
+      catch (System.Exception ex)
+      {
+        Console.WriteLine("Failure: "+ex.Message+" stack:\n"+ex.StackTrace);
+        result = -1;
+      }
+      return result;
+    }
+
+    /*
+    Now we have our state processing functions.
+    For each set of states we have a separate function that expects a uint
+    (which represents the Unicode character in question). There are three possible
+    results from being in a state and receiving a character.
+    1) Move forward to a new state.
+    2) Notice an error and spit out the currently stored data unchanged
+    3) Notice that the match is complete and translate it.
+
+    By far the largest section of code will be to move forward to a new state,
+    and each potential move forward will hake a check for errors. Occasionally,
+    an ``error'' state will actually indicate a successful completion and we
+    will do a translation.
+
+    Let's start with our storage and state management followed by declaring our
+    state progression functions.
+
+    One final note, this SignWriting converter is actually too permissive.
+    In this converter you can use unicode for the symbol and ``text'' for
+    the numbers, or the reverse. I believe that you should actually be
+    required to do one or the other, but there it is. If I were ever to make a
+    version that did not let you mix and match FSWA and FSWU, we would have two
+    sets of functions.
+
+    It's may also not be permissive enough in that if you have "AS123M", it may
+    miss that M starts a word. I didn't bother testing for this behavior. I also
+    don't look through a partially accepted string to see if a new one should
+    start so if you say "M500x500S10000500x500S" then this is a failure and the
+    first portion will not be translated.
+
+    Each of these states tells us what is being expected. So, for instance,
+    start_start_start is expecting to see a word start. If it doesn't, then it just
+    sends the character along. But visual_size_secondw is expecting the second digit
+    of the number expressing the width. If it doesn't, then it will need to spit out
+    what it has already stored and then go back to start. This is also why there
+    aren't any functions for "_end", that would mean that it's expecting one
+    character past the last one.
+    */
+
+    uint[] line = {};
+
+    int fswtotex(FileStream fileIn, FileStream fileOut)
+    {
+      state=substate=subsubstate=s_start;
+      uint c=0;
+      while(c!=0xffffffff)
+      {
+        c=getChar(fileIn);
+        if(c==0xffffffff)
+          continue;
+        if     (state==s_start)       start (fileOut, c);
+        else if(state==s_prefix)      prefix(fileOut, c);
+        else if(state==s_visual)      visual(fileOut, c);
+        else if(state==s_punctuation) punctuation(fileOut, c);
+        else throw new System.Exception("Unknown state.");
+      }
+      string line="";
+      byte[] toSend={};
+      line = "\n";
+      stringToByte(line, ref toSend);
+      fileOut.Write(toSend,0,toSend.Length);
+      line="% In order for this conversion to work your document needs a few things.\n";
+      stringToByte(line, ref toSend);
+      fileOut.Write(toSend,0,toSend.Length);
+      line="% \\usepackage{fontspec}\n";
+      stringToByte(line, ref toSend);
+      fileOut.Write(toSend,0,toSend.Length);
+      line="% \\usepackage{tikz}\n";
+      stringToByte(line, ref toSend);
+      fileOut.Write(toSend,0,toSend.Length);
+      line="% \\begin{document}\n";
+      stringToByte(line, ref toSend);
+      fileOut.Write(toSend,0,toSend.Length);
+      line="% \\newfontfamily\\swfill{SuttonSignWritingFill.ttf}\n";
+      stringToByte(line, ref toSend);
+      fileOut.Write(toSend,0,toSend.Length);
+      line="% \\newfontfamily\\swline{SuttonSignWritingLine.ttf}\n";
+      stringToByte(line, ref toSend);
+      fileOut.Write(toSend,0,toSend.Length);
+      return 0;
+    }
+
+    /*
+    We are going to cover these states breadth first.
+    That is, all the base states, then the two-level states, then ...
+    */
+
+    void start(FileStream fileOut, uint c)
+    {
+      if(substate==s_start) start_start(fileOut, c);
+      else throw new System.Exception("Unknown substate in start.");
+    }
+
+    void prefix(FileStream fileOut, uint c)
+    {
+      if(substate==s_symbol) prefix_symbol(fileOut, c);
+      else throw new System.Exception("Unknown substate in prefix.");
+    }
+
+    void visual(FileStream fileOut, uint c)
+    {
+      if     (substate==s_start)     visual_start    (fileOut, c);
+      else if(substate==s_size)      visual_size     (fileOut, c);
+      else if(substate==s_symbol)    visual_symbol   (fileOut, c);
+      else if(substate==s_placement) visual_placement(fileOut, c);
+      else throw new System.Exception("Unknown substate in visual.");
+    }
+
+    void punctuation(FileStream fileOut, uint c)
+    {
+      if     (substate==s_start)     punctuation_start    (fileOut, c);
+      else if(substate==s_symbol)    punctuation_symbol   (fileOut, c);
+      else if(substate==s_placement) punctuation_placement(fileOut, c);
+      else throw new System.Exception("Unknown substate in punctuation.");
+    }
+
+    void start_start(FileStream fileOut, uint c)
+    {
+      if(subsubstate==s_start) start_start_start(fileOut, c);
+      else throw new System.Exception("Unknown subsubstate start, start.");
+    }
+
+    void prefix_symbol(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_start)    prefix_symbol_start   (fileOut, c);
+      else if(subsubstate==s_first)    prefix_symbol_first   (fileOut, c);
+      else if(subsubstate==s_second)   prefix_symbol_second  (fileOut, c);
+      else if(subsubstate==s_third)    prefix_symbol_third   (fileOut, c);
+      else if(subsubstate==s_fill)     prefix_symbol_fill    (fileOut, c);
+      else if(subsubstate==s_rotation) prefix_symbol_rotation(fileOut, c);
+      else throw new System.Exception("Unknown subsubstate in prefxi, symbol.");
+    }
+
+    void visual_start(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_start) visual_start_start(fileOut, c);
+      else throw new System.Exception("Unknown subsubstate in visual, start.");
+    }
+
+    void visual_size(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_firstw)  visual_size_firstw (fileOut, c);
+      else if(subsubstate==s_secondw) visual_size_secondw(fileOut, c);
+      else if(subsubstate==s_thirdw)  visual_size_thirdw (fileOut, c);
+      else if(subsubstate==s_x)       visual_size_x      (fileOut, c);
+      else if(subsubstate==s_firsth)  visual_size_firsth (fileOut, c);
+      else if(subsubstate==s_secondh) visual_size_secondh(fileOut, c);
+      else if(subsubstate==s_thirdh)  visual_size_thirdh (fileOut, c);
+      else throw new System.Exception("Unknown subsubstate in visual, size.");
+    }
+
+    void visual_symbol(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_start)    visual_symbol_start   (fileOut, c);
+      else if(subsubstate==s_first)    visual_symbol_first   (fileOut, c);
+      else if(subsubstate==s_second)   visual_symbol_second  (fileOut, c);
+      else if(subsubstate==s_third)    visual_symbol_third   (fileOut, c);
+      else if(subsubstate==s_fill)     visual_symbol_fill    (fileOut, c);
+      else if(subsubstate==s_rotation) visual_symbol_rotation(fileOut, c);
+      else throw new System.Exception("Unknown subsubstate int visual, symbol.");
+    }
+
+    void visual_placement(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_firstw)  visual_placement_firstw (fileOut, c);
+      else if(subsubstate==s_secondw) visual_placement_secondw(fileOut, c);
+      else if(subsubstate==s_thirdw)  visual_placement_thirdw (fileOut, c);
+      else if(subsubstate==s_x)       visual_placement_x      (fileOut, c);
+      else if(subsubstate==s_firsth)  visual_placement_firsth (fileOut, c);
+      else if(subsubstate==s_secondh) visual_placement_secondh(fileOut, c);
+      else if(subsubstate==s_thirdh)  visual_placement_thirdh (fileOut, c);
+      else if(subsubstate==s_end)     visual_placement_end    (fileOut, c);
+      else throw new System.Exception("Unknown subsubstate in visual, placement.");
+    }
+
+    void punctuation_start(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_start) punctuation_start_start(fileOut, c);
+      else throw new System.Exception("Unknown subsubstate in punctuation, start.");
+    }
+
+    void punctuation_symbol(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_start)    punctuation_symbol_start   (fileOut, c);
+      else if(subsubstate==s_first)    punctuation_symbol_first   (fileOut, c);
+      else if(subsubstate==s_second)   punctuation_symbol_second  (fileOut, c);
+      else if(subsubstate==s_third)    punctuation_symbol_third   (fileOut, c);
+      else if(subsubstate==s_fill)     punctuation_symbol_fill    (fileOut, c);
+      else if(subsubstate==s_rotation) punctuation_symbol_rotation(fileOut, c);
+      else throw new System.Exception("Unknown subsubstate int punctuation, symbol.");
+    }
+
+    void punctuation_placement(FileStream fileOut, uint c)
+    {
+      if     (subsubstate==s_firstw)  punctuation_placement_firstw (fileOut, c);
+      else if(subsubstate==s_secondw) punctuation_placement_secondw(fileOut, c);
+      else if(subsubstate==s_thirdw)  punctuation_placement_thirdw (fileOut, c);
+      else if(subsubstate==s_x)       punctuation_placement_x      (fileOut, c);
+      else if(subsubstate==s_firsth)  punctuation_placement_firsth (fileOut, c);
+      else if(subsubstate==s_secondh) punctuation_placement_secondh(fileOut, c);
+      else if(subsubstate==s_thirdh)  punctuation_placement_thirdh (fileOut, c);
+      else if(subsubstate==s_end)     punctuation_placement_end    (fileOut, c);
+      else throw new System.Exception("Unknown subsubstate in punctuation, placement.");
+    }
+
+    void start_start_start(FileStream fileOut, uint c)
+    {
+      if(c=='A' || c==0x1d800)
+        { Add(ref line,c); state=s_prefix; substate=s_symbol; subsubstate=s_start; }
+      else if(c=='B' || (c>='L'&&c<='M') || c=='R' || (c>=0x1d801&&c<=0x1d804))
+        { Add(ref line,c); state=s_visual; substate=s_size; subsubstate=s_firstw; }
+      else if(c=='S')
+        { Add(ref line,c); state=s_punctuation; substate=s_symbol; subsubstate=s_first; }
+      else
+        sendOut(fileOut, c);
+    }
+
+    void prefix_symbol_start(FileStream fileOut, uint c)
+    {
+       if(c=='S')
+        { Add(ref line, c); subsubstate=s_first; }
+       else if(c>=0x40001 && c<=0x4f428)
+        { Add(ref line, c); state=s_visual; substate=s_start; subsubstate=s_start; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void prefix_symbol_first(FileStream fileOut, uint c)
+    {
+      if(c>='1' && c<='3')
+        { Add(ref line, c); subsubstate=s_second; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void prefix_symbol_second(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]>='0'&&line[line.Length-1]<='2')
+      {
+        if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+          { Add(ref line, c); subsubstate=s_third; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else
+      {
+        if(c>='0' && c<='8')
+          { Add(ref line, c); subsubstate=s_third; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void prefix_symbol_third(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-2]>='0'&&line[line.Length-2]<='2')
+      {
+        if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+          { Add(ref line, c); subsubstate=s_fill; }
+        else
+            sendOut(fileOut, ref line, c);
+      }
+      else
+      {
+        if(line[line.Length-1]>='0'&&line[line.Length-1]<='7')
+        {
+          if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+            { Add(ref line, c); subsubstate=s_fill; }
+          else
+            sendOut(fileOut, ref line, c);
+        }
+        else
+        {
+          if((c>='0'&&c<='9') || (c>='a'&&c<='b'))
+            { Add(ref line, c); subsubstate=s_fill; }
+          else
+            sendOut(fileOut, ref line, c);
+        }
+      }
+    }
+
+    void prefix_symbol_fill(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='5')
+        { Add(ref line, c); subsubstate=s_rotation; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void prefix_symbol_rotation(FileStream fileOut, uint c)
+    {
+      if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+        { Add(ref line, c); state=s_visual; substate=subsubstate=s_start; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_start_start(FileStream fileOut, uint c)
+    {
+      if(c=='B' || (c>='L'&&c<='M') || c=='R' || (c>=0x1d801&&c<=0x1d804))
+        { Add(ref line, c); substate=s_size; subsubstate=s_firstw; }
+      else if(c=='S')
+        { Add(ref line, c); state=s_prefix; substate=s_symbol; subsubstate=s_first; }
+      else if(c>=0x40001 && c<=0x4f428)
+        { Add(ref line, c); state=s_visual; substate=s_start; subsubstate=s_start; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_size_firstw(FileStream fileOut, uint c)
+    {
+      if(c>='2' && c<='7')
+        { Add(ref line, c); subsubstate=s_secondw; }
+      else if(c>=0x1d80c && c<=0x1d9ff)
+        { Add(ref line, c); subsubstate=s_firsth; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_size_secondw(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]=='2')
+      {
+        if( c>='5' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else if(line[line.Length-1]>='3'&&line[line.Length-1]<='6')
+      {
+        if( c>='0' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else // if(line[line.Length-1]=='7')
+      {
+        if( c>='0' && c<='4')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void visual_size_thirdw(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='9')
+        { Add(ref line, c); subsubstate=s_x; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_size_x(FileStream fileOut, uint c)
+    {
+      if(c=='x')
+        { Add(ref line, c); subsubstate=s_firsth; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_size_firsth(FileStream fileOut, uint c)
+    {
+      if(c>='2' && c<='7')
+        { Add(ref line, c); subsubstate=s_secondh; }
+      else if(c>=0x1d80c && c<=0x1d9ff)
+        { Add(ref line, c); substate=s_symbol; subsubstate=s_start; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_size_secondh(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]=='2')
+      {
+        if( c>='5' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else if(line[line.Length-1]>='3'&&line[line.Length-1]<='6')
+      {
+        if( c>='0' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else // if(line[line.Length-1]=='7')
+      {
+        if( c>='0' && c<='4')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void visual_size_thirdh(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='9')
+        { Add(ref line, c); substate=s_symbol; subsubstate=s_start; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_symbol_start(FileStream fileOut, uint c)
+    {
+      if(c=='S')
+        { Add(ref line, c); subsubstate=s_first; }
+      else if(c>=0x40001 && c<=0x4f428)
+        { Add(ref line, c); state=s_visual; substate=s_placement; subsubstate=s_first; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_symbol_first(FileStream fileOut, uint c)
+    {
+      if(c>='1' && c<='3')
+        { Add(ref line, c); subsubstate=s_second; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_symbol_second(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]>='0'&&line[line.Length-1]<='2')
+      {
+        if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+          { Add(ref line, c); subsubstate=s_third; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else
+      {
+        if(c>='0' && c<='8')
+          { Add(ref line, c); subsubstate=s_third; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void visual_symbol_third(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-2]>='0'&&line[line.Length-2]<='2')
+      {
+        if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+          { Add(ref line, c); subsubstate=s_fill; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else
+      {
+        if(line[line.Length-1]>='0'&&line[line.Length-1]<='7')
+        {
+          if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+            { Add(ref line, c); subsubstate=s_fill; }
+          else
+            sendOut(fileOut, ref line, c);
+        }
+        else
+        {
+          if((c>='0'&&c<='9') || (c>='a'&&c<='b'))
+            { Add(ref line, c); subsubstate=s_fill; }
+          else
+            sendOut(fileOut, ref line, c);
+        }
+      }
+    }
+
+    void visual_symbol_fill(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='5')
+        { Add(ref line, c); subsubstate=s_rotation; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_symbol_rotation(FileStream fileOut, uint c)
+    {
+      if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+        { Add(ref line, c); substate=s_placement; subsubstate=s_firstw; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_placement_firstw(FileStream fileOut, uint c)
+    {
+      if(c>='2' && c<='7')
+        { Add(ref line, c); subsubstate=s_secondw; }
+      else if(c>=0x1d80c && c<=0x1d9ff)
+        { Add(ref line, c); subsubstate=s_firsth; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_placement_secondw(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]=='2')
+      {
+        if( c>='5' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else if(line[line.Length-1]>='3'&&line[line.Length-1]<='6')
+      {
+        if( c>='0' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else // if(line[line.Length-1]=='7')
+      {
+        if( c>='0' && c<='4')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void visual_placement_thirdw(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='9')
+        { Add(ref line, c); subsubstate=s_x; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_placement_x(FileStream fileOut, uint c)
+    {
+      if(c=='x')
+        { Add(ref line, c); subsubstate=s_firsth; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_placement_firsth(FileStream fileOut, uint c)
+    {
+      if(c>='2' && c<='7')
+        { Add(ref line, c); subsubstate=s_secondh; }
+      else if(c>=0x1d80c && c<=0x1d9ff)
+        { Add(ref line, c); subsubstate=s_end; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_placement_secondh(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]=='2')
+      {
+        if( c>='5' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else if(line[line.Length-1]>='3'&&line[line.Length-1]<='6')
+      {
+        if( c>='0' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else // if(line[line.Length-1]=='7')
+      {
+        if( c>='0' && c<='4')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void visual_placement_thirdh(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='9')
+        { Add(ref line, c); subsubstate=s_end; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void visual_placement_end(FileStream fileOut, uint c)
+    {
+      if(c=='S')
+        { Add(ref line, c); substate=s_symbol; subsubstate=s_first; }
+      else if(c>=0x40001 && c<=0x4f428)
+        { Add(ref line, c); state=s_visual; substate=s_placement; subsubstate=s_first; }
+      else
+      {
+        state=substate=subsubstate=s_start;
+        uint place=0;
+        char lane='B';
+        if(line[place]=='A' || line[place]==0x1d800)
+        {
+           place++;
+           while(line[place]=='S' || (line[place]>=0x40001 && line[place]<=0x4f428))
+           {
+             if(line[place]=='S') place+=6;
+             else                 place++;
+           }
+        }
+        if(line[place]=='B' || line[place]==0x1d801)
+          lane='B';
+        if(line[place]=='L' || line[place]==0x1d802)
+          lane='L';
+        if(line[place]=='M' || line[place]==0x1d803)
+          lane='M';
+        if(line[place]=='R' || line[place]==0x1d804)
+          lane='R';
+        place++;
+        // We currently ignore the height and width, so we just skip over them.
+        if(line[place]>'2' && line[place]<='7')
+        {
+          place += 3;
+          // and skip the x
+          place++;
+        }
+        else
+        {
+          place++;
+        }
+        if(line[place]>'2' && line[place]<='7')
+        {
+          place += 3;
+        }
+        else
+        {
+          place++;
+        }
+        string lineOut="";
+        byte[] toSend={};
+        lineOut="{\\uccoff";
+        stringToByte(lineOut, ref toSend);
+        fileOut.Write(toSend,0,toSend.Length);
+        lineOut="\\begin{tikzpicture}[rotate=-90,yscale=-1]";
+        stringToByte(lineOut, ref toSend);
+        fileOut.Write(toSend,0,toSend.Length);
+        // The idea was, initally, to place a thin rectangle behind each character from 0--1000.
+        // Unfortunately, this made it so that I could reasonably fit about two columns of
+        // \normalsize text to a page. We are now only extend 100 each direction to allow for about
+        // five columns of \normalsize text. This also decided our lane shift amount later on.
+
+        // Yes, I know the number 100 doesn't appear. That's because I found through experimentation
+        // that a character anchored at (0,0) along with a rectangle around (0,0) does not place a
+        // rectangle around the expected corner.
+        if(lane != 'B')
+        {
+          lineOut="\\draw[white](\\FontSize/30*-90 pt,\\FontSize/30*-12 pt)rectangle(\\FontSize/30*110 pt,\\FontSize/30*-10 pt);";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+        }
+        while(place<line.Length)
+        {
+          int s;
+          if(line[place]=='S')
+          {
+            place++;
+            s=(int)(line[place]-'0')*256;
+            if(line[place+1]>='0' && line[place+1]<='9')
+              s+=(int)(line[place+1]-'0')*16;
+            else // if(line[place+1]>='a' && line[place+1]<='f')
+              s+=(int)(line[place+1]-'a'+10)*16;
+            if(line[place+2]>='0' && line[place+2]<='9')
+              s+=(int)(line[place+2]-'0')*1;
+            else // if(line[place+2]>='a' && line[place+2]<='f')
+              s+=(int)(line[place+2]-'a'+10)*1;
+            place+=3;
+            s-=0x100;
+            s*=(6*16);
+            s+=(int)(line[place]-'0')*16;
+            place++;
+            if(line[place]>='0' && line[place]<='9')
+              s+=(int)(line[place]-'0');
+            else // if(line[place+1]>='a' && line[place+1]<='f')
+              s+=(int)(line[place]-'a'+10);
+            place++;
+          }
+          else // if(line[place]>=0x40001 && line[place]<=0x4f428)
+          {
+            s=(int)line[place]-0x40001;
+            place++;
+          }
+          int sx;
+          if(line[place]>'2' && line[place]<='7')
+          {
+            sx=(int)((line[place]-'0')*100 + (line[place+1]-'0')*10 + (line[place+2]-'0'));
+            place += 3;
+            // and skip the x
+            place++;
+          }
+          else
+          {
+            sx=(int)line[place]-0x1d80c+250;
+            place++;
+          }
+          int sy;
+          if(line[place]>'2' && line[place]<='7')
+          {
+            sy=(int)((line[place]-'0')*100 + (line[place+1]-'0')*10 + (line[place+2]-'0'));
+            place += 3;
+          }
+          else
+          {
+            sy=(int)line[place]-0x1d80c+250;
+            place++;
+          }
+          /*
+          At this point, assuming well formed F/USW strings, we will
+          Have a symbol centered around (500,500).
+          For 'B' (meaning horizontal SW) we center it around (0,0).
+          For 'L' we shift it left 250.
+          For 'M' it is correct.
+          For 'R' we shift it right 250.
+          */
+          if(lane=='B')
+            sx-=500;
+          if(lane=='L')
+            sx-=550;
+          if(lane=='M')
+            sx-=500;
+          if(lane=='R')
+            sx-=450;
+          sy-=500;
+          // Now we know where, but for SignWriting the white space can be important too.
+          lineOut="\\draw(\\FontSize/30*";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=sx.ToString();
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=" pt,\\FontSize/30*";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=(-sy).ToString();
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=" pt) node [xscale=-1,rotate=-90,color=white,anchor=north west] {\\swfill\\fontsize{\\FontSize}{\\FontSize}\\selectfont\\char";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=(0x100001+s).ToString();
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut="};";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut="\\draw(\\FontSize/30*";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=sx.ToString();
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=" pt,\\FontSize/30*";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=(-sy).ToString();
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=" pt) node [xscale=-1,rotate=-90,anchor=north west] {\\swline\\fontsize{\\FontSize}{\\FontSize}\\selectfont\\char";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut=(0xf0001+s).ToString();
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+          lineOut="};";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+        }
+        lineOut="\\end{tikzpicture}";
+        stringToByte(lineOut, ref toSend);
+        fileOut.Write(toSend,0,toSend.Length);
+        lineOut="\\uccon}";
+        stringToByte(lineOut, ref toSend);
+        fileOut.Write(toSend,0,toSend.Length);
+        /*if(lane!='B')
+        {
+          lineOut="\\\\";
+          stringToByte(lineOut, ref toSend);
+          fileOut.Write(toSend,0,toSend.Length);
+        }*/
+        Array.Resize(ref line, 0);
+        lineOut=((char)(c)).ToString();
+        stringToByte(lineOut, ref toSend);
+        fileOut.Write(toSend,0,toSend.Length);
+        state=substate=subsubstate=s_start;
+      }
+    }
+
+    void punctuation_start_start(FileStream fileOut, uint c)
+    {
+      if(c=='S')
+        { Add(ref line, c); substate=s_symbol; subsubstate=s_first; }
+      else if(c>=0x4f424 && c<=0x4f428)
+        { Add(ref line, c); substate=s_placement; subsubstate=s_first; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_symbol_start(FileStream fileOut, uint c)
+    {
+      if(c=='S')
+        { Add(ref line, c); substate=s_symbol; subsubstate=s_first; }
+      else if(c>=0x4f424 && c<=0x4f428)
+        { Add(ref line, c); substate=s_placement; subsubstate=s_first; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_symbol_first(FileStream fileOut, uint c)
+    {
+      if(c=='3')
+        { Add(ref line, c); subsubstate=s_second; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_symbol_second(FileStream fileOut, uint c)
+    {
+      if(c=='8')
+        { Add(ref line, c); subsubstate=s_third; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_symbol_third(FileStream fileOut, uint c)
+    {
+      if((c>='7'&&c<='9') || (c>='a'&&c<='b'))
+        { Add(ref line, c); subsubstate=s_fill; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_symbol_fill(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='5')
+        { Add(ref line, c); subsubstate=s_rotation; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_symbol_rotation(FileStream fileOut, uint c)
+    {
+      if((c>='0'&&c<='9') || (c>='a'&&c<='f'))
+        { Add(ref line, c); substate=s_placement; subsubstate=s_firstw; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_placement_firstw(FileStream fileOut, uint c)
+    {
+      if(c>='2' && c<='7')
+        { Add(ref line, c); subsubstate=s_secondw; }
+      else if(c>=0x1d80c && c<=0x1d9ff)
+        { Add(ref line, c); subsubstate=s_firsth; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_placement_secondw(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]=='2')
+      {
+        if( c>='5' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else if(line[line.Length-1]>='3'&&line[line.Length-1]<='6')
+      {
+        if( c>='0' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else // if(line[line.Length-1]=='7')
+      {
+        if( c>='0' && c<='4')
+          { Add(ref line, c); subsubstate=s_thirdw; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void punctuation_placement_thirdw(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='9')
+        { Add(ref line, c); subsubstate=s_x; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_placement_x(FileStream fileOut, uint c)
+    {
+      if(c=='x')
+        { Add(ref line, c); subsubstate=s_firsth; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_placement_firsth(FileStream fileOut, uint c)
+    {
+      if(c>='2' && c<='7')
+        { Add(ref line, c); subsubstate=s_secondh; }
+      else if(c>=0x1d80c && c<=0x1d9ff)
+        { Add(ref line, c); subsubstate=s_end; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_placement_secondh(FileStream fileOut, uint c)
+    {
+      if(line[line.Length-1]=='2')
+      {
+        if( c>='5' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else if(line[line.Length-1]>='3'&&line[line.Length-1]<='6')
+      {
+        if( c>='0' && c<='9')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+      else // if(line[line.Length-1]=='7')
+      {
+        if( c>='0' && c<='4')
+          { Add(ref line, c); subsubstate=s_thirdh; }
+        else
+          sendOut(fileOut, ref line, c);
+      }
+    }
+
+    void punctuation_placement_thirdh(FileStream fileOut, uint c)
+    {
+      if(c>='0' && c<='9')
+        { Add(ref line, c); subsubstate=s_end; }
+      else
+        sendOut(fileOut, ref line, c);
+    }
+
+    void punctuation_placement_end(FileStream fileOut, uint c)
+    {
+      uint[] temp = {'M','5','0','0','x','5','0','0'};
+      foreach(uint u in line)
+          Add(ref temp, u);
+      Array.Resize(ref line, 0);
+      foreach(uint u in temp)
+          Add(ref line, u);
+      visual_placement_end(fileOut, c);
+    } 
+  }
+}

--- a/fswtotex/Program.cs
+++ b/fswtotex/Program.cs
@@ -37,7 +37,7 @@ using System.IO;
         Placement   -- processing the placement of the symbol
         End         -- Time for the outer state machine to finish
 
-    The Punctuation state machine hase the following states:
+    The Punctuation state machine has the following states:
         Symbol      -- processing a base symbol
         Placement   -- processing the placement of the symbol
         End         -- Time for the outer state machine to finish

--- a/fswtotex/Properties/AssemblyInfo.cs
+++ b/fswtotex/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("fswtotex")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("fswtotex")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1a7ed36b-3545-45a5-9e80-b721934a6e72")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/fswtotex/app.config
+++ b/fswtotex/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/fswtotex/fswtotex.csproj
+++ b/fswtotex/fswtotex.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>1.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{78cca0e2-976f-4bd4-868a-65a996d7974c}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>fswtotex</RootNamespace>
+    <AssemblyName>fswtotex</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <IntermediateOutputPath>C:\Users\KAHUNA~1\AppData\Local\Temp\vsE0E0.tmp\x86\Debug\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <IntermediateOutputPath>C:\Users\KAHUNA~1\AppData\Local\Temp\vsE0E0.tmp\x86\Release\</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.IO" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/haiola/haiola.Designer.cs
+++ b/haiola/haiola.Designer.cs
@@ -173,7 +173,7 @@
             this.extendUsfmCheckBox = new System.Windows.Forms.CheckBox();
             this.label21 = new System.Windows.Forms.Label();
             this.promoTextBox = new System.Windows.Forms.TextBox();
-            this.scriptTextBox = new System.Windows.Forms.TextBox();
+            this.scriptComboBox = new System.Windows.Forms.ComboBox();
             this.label61 = new System.Windows.Forms.Label();
             this.label59 = new System.Windows.Forms.Label();
             this.ldmlTextBox = new System.Windows.Forms.TextBox();
@@ -1768,7 +1768,7 @@
             this.advancedTabPage.Controls.Add(this.extendUsfmCheckBox);
             this.advancedTabPage.Controls.Add(this.label21);
             this.advancedTabPage.Controls.Add(this.promoTextBox);
-            this.advancedTabPage.Controls.Add(this.scriptTextBox);
+            this.advancedTabPage.Controls.Add(this.scriptComboBox);
             this.advancedTabPage.Controls.Add(this.label61);
             this.advancedTabPage.Controls.Add(this.label59);
             this.advancedTabPage.Controls.Add(this.ldmlTextBox);
@@ -1915,13 +1915,216 @@
             this.promoTextBox.Size = new System.Drawing.Size(480, 121);
             this.promoTextBox.TabIndex = 111;
             // 
-            // scriptTextBox
-            // 
-            this.scriptTextBox.Location = new System.Drawing.Point(328, 35);
-            this.scriptTextBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.scriptTextBox.Name = "scriptTextBox";
-            this.scriptTextBox.Size = new System.Drawing.Size(167, 20);
-            this.scriptTextBox.TabIndex = 110;
+            // scriptComboBox
+            //
+            this.scriptComboBox.FormattingEnabled = true;
+            // Most recent addition 2020-04-16
+            this.scriptComboBox.Items.AddRange(new object[] {
+            "Adlm-Adlam",
+            "Afak-Afaka",
+            "Aghb-Caucasian Albanian",
+            "Ahom-Ahom, Tai Ahom",
+            "Arab-Arabic",
+            "Aran-Arabic (Nastaliq variant)",
+            "Armi-Imperial Aramaic",
+            "Armn-Armenian",
+            "Avst-Avestan",
+            "Bali-Balinese",
+            "Bamu-Bamum",
+            "Bass-Bassa Vah",
+            "Batk-Batak",
+            "Beng-Bengali (Bangla)",
+            "Bhks-Bhaiksuki",
+            "Blis-Blissymbols",
+            "Bopo-Bopomofo",
+            "Brah-Brahmi",
+            "Brai-Braille",
+            "Bugi-Buginese",
+            "Buhd-Buhid",
+            "Cakm-Chakma",
+            "Cans-Unified Canadian Aboriginal Syllabics",
+            "Cari-Carian",
+            "Cham-Cham",
+            "Cher-Cherokee",
+            "Cirt-Cirth",
+            "Copt-Coptic",
+            "Cpmn-Cypro-Minoan",
+            "Cprt-Cypriot syllabary",
+            "Cyrl-Cyrillic",
+            "Cyrs-Cyrillic (Old Church Slavonic variant)",
+            "Deva-Devanagari (Nagari)",
+            "Dogr-Dogra",
+            "Dsrt-Deseret (Mormon)",
+            "Dupl-Duployan shorthand, Duployan stenography",
+            "Egyd-Egyptian demotic",
+            "Egyh-Egyptian hieratic",
+            "Egyp-Egyptian hieroglyphs",
+            "Elba-Elbasan",
+            "Elym-Elymaic",
+            "Ethi-Ethiopic (Geʻez)",
+            "Geok-Khutsuri (Asomtavruli and Nuskhuri)",
+            "Geor-Georgian (Mkhedruli and Mtavruli)",
+            "Glag-Glagolitic",
+            "Gong-Gunjala Gondi",
+            "Gonm-Masaram Gondi",
+            "Goth-Gothic",
+            "Gran-Grantha",
+            "Grek-Greek",
+            "Gujr-Gujarati",
+            "Guru-Gurmukhi",
+            "Hanb-Han with Bopomofo (alias for Han + Bopomofo)",
+            "Hang-Hangul (Hangŭl, Hangeul)",
+            "Hani-Han (Hanzi, Kanji, Hanja)",
+            "Hano-Hanunoo (Hanunóo)",
+            "Hans-Han (Simplified variant)",
+            "Hant-Han (Traditional variant)",
+            "Hatr-Hatran",
+            "Hebr-Hebrew",
+            "Hira-Hiragana",
+            "Hluw-Anatolian Hieroglyphs (Luwian Hieroglyphs, Hittite Hieroglyphs)",
+            "Hmng-Pahawh Hmong",
+            "Hmnp-Nyiakeng Puachue Hmong",
+            "Hrkt-Japanese syllabaries (alias for Hiragana + Katakana)",
+            "Hung-Old Hungarian (Hungarian Runic)",
+            "Inds-Indus (Harappan)",
+            "Ital-Old Italic (Etruscan, Oscan, etc.)",
+            "Jamo-Jamo (alias for Jamo subset of Hangul)",
+            "Java-Javanese",
+            "Jpan-Japanese (alias for Han + Hiragana + Katakana)",
+            "Jurc-Jurchen",
+            "Kali-Kayah Li",
+            "Kana-Katakana",
+            "Khar-Kharoshthi",
+            "Khmr-Khmer",
+            "Khoj-Khojki",
+            "Kitl-Khitan large script",
+            "Kits-Khitan small script",
+            "Knda-Kannada",
+            "Kore-Korean (alias for Hangul + Han)",
+            "Kpel-Kpelle",
+            "Kthi-Kaithi",
+            "Lana-Tai Tham (Lanna)",
+            "Laoo-Lao",
+            "Latf-Latin (Fraktur variant)",
+            "Latg-Latin (Gaelic variant)",
+            "Latn-Latin",
+            "Leke-Leke",
+            "Lepc-Lepcha (Róng)",
+            "Limb-Limbu",
+            "Lina-Linear A",
+            "Linb-Linear B",
+            "Lisu-Lisu (Fraser)",
+            "Loma-Loma",
+            "Lyci-Lycian",
+            "Lydi-Lydian",
+            "Mahj-Mahajani",
+            "Maka-Makasar",
+            "Mand-Mandaic, Mandaean",
+            "Mani-Manichaean",
+            "Marc-Marchen",
+            "Maya-Mayan hieroglyphs",
+            "Medf-Medefaidrin (Oberi Okaime, Oberi Ɔkaimɛ)",
+            "Mend-Mende Kikakui",
+            "Merc-Meroitic Cursive",
+            "Mero-Meroitic Hieroglyphs",
+            "Mlym-Malayalam",
+            "Modi-Modi, Moḍī",
+            "Mong-Mongolian",
+            "Moon-Moon (Moon code, Moon script, Moon type)",
+            "Mroo-Mro, Mru",
+            "Mtei-Meitei Mayek (Meithei, Meetei)",
+            "Mult-Multani",
+            "Mymr-Myanmar (Burmese)",
+            "Nand-Nandinagari",
+            "Narb-Old North Arabian (Ancient North Arabian)",
+            "Nbat-Nabataean",
+            "Newa-Newa, Newar, Newari, Nepāla lipi",
+            "Nkdb-Naxi Dongba (na²¹ɕi³³ to³³ba²¹, Nakhi Tomba)",
+            "Nkgb-Naxi Geba (na²¹ɕi³³ gʌ²¹ba²¹, 'Na-'Khi ²Ggŏ-¹baw, Nakhi Geba)",
+            "Nkoo-N’Ko",
+            "Nshu-Nüshu",
+            "Ogam-Ogham",
+            "Olck-Ol Chiki (Ol Cemet’, Ol, Santali)",
+            "Orkh-Old Turkic, Orkhon Runic",
+            "Orya-Oriya (Odia)",
+            "Osge-Osage",
+            "Osma-Osmanya",
+            "Palm-Palmyrene",
+            "Pauc-Pau Cin Hau",
+            "Perm-Old Permic",
+            "Phag-Phags-pa",
+            "Phli-Inscriptional Pahlavi",
+            "Phlp-Psalter Pahlavi",
+            "Phlv-Book Pahlavi",
+            "Phnx-Phoenician",
+            "Plrd-Miao (Pollard)",
+            "Piqd-Klingon (KLI pIqaD)",
+            "Prti-Inscriptional Parthian",
+            "Qaaa-Reserved for private use (start)",
+            "Qabx-Reserved for private use (end)",
+            "Rjng-Rejang (Redjang, Kaganga)",
+            "Rohg-Hanifi Rohingya",
+            "Roro-Rongorongo",
+            "Runr-Runic",
+            "Samr-Samaritan",
+            "Sara-Sarati",
+            "Sarb-Old South Arabian",
+            "Saur-Saurashtra",
+            "Sgnw-SignWriting",
+            "Shaw-Shavian (Shaw)",
+            "Shrd-Sharada, Śāradā",
+            "Shui-Shuishu",
+            "Sidd-Siddham, Siddhaṃ, Siddhamātṛkā",
+            "Sind-Khudawadi, Sindhi",
+            "Sinh-Sinhala",
+            "Sogd-Sogdian",
+            "Sogo-Old Sogdian",
+            "Sora-Sora Sompeng",
+            "Soyo-Soyombo",
+            "Sund-Sundanese",
+            "Sylo-Syloti Nagri",
+            "Syrc-Syriac",
+            "Syre-Syriac (Estrangelo variant)",
+            "Syrj-Syriac (Western variant)",
+            "Syrn-Syriac (Eastern variant)",
+            "Tagb-Tagbanwa",
+            "Takr-Takri, Ṭākrī, Ṭāṅkrī",
+            "Tale-Tai Le",
+            "Talu-New Tai Lue",
+            "Taml-Tamil",
+            "Tang-Tangut",
+            "Tavt-Tai Viet",
+            "Telu-Telugu",
+            "Teng-Tengwar",
+            "Tfng-Tifinagh (Berber)",
+            "Tglg-Tagalog (Baybayin, Alibata)",
+            "Thaa-Thaana",
+            "Thai-Thai",
+            "Tibt-Tibetan",
+            "Tirh-Tirhuta",
+            "Toto-Toto",
+            "Ugar-Ugaritic",
+            "Vaii-Vai",
+            "Visp-Visible Speech",
+            "Wara-Warang Citi (Varang Kshiti)",
+            "Wcho-Wancho",
+            "Wole-Woleai",
+            "Xpeo-Old Persian",
+            "Xsux-Cuneiform, Sumero-Akkadian",
+            "Yiii-Yi",
+            "Zanb-Zanabazar Square (Zanabazarin Dörböljin Useg, Xewtee Dörböljin Bicig, Horizontal Square Script)",
+            "Zinh-Code for inherited script",
+            "Zmth-Mathematical notation",
+            "Zsye-Symbols (Emoji variant)",
+            "Zsym-Symbols",
+            "Zxxx-Code for unwritten documents",
+            "Zyyy-Code for undetermined script",
+            "Zzzz-Code for uncoded script"});
+            this.scriptComboBox.Location = new System.Drawing.Point(328, 35);
+            this.scriptComboBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.scriptComboBox.Name = "scriptComboBox";
+            this.scriptComboBox.Size = new System.Drawing.Size(167, 20);
+            this.scriptComboBox.TabIndex = 110;
             // 
             // label61
             // 
@@ -2038,7 +2241,8 @@
             this.textDirectionComboBox.Items.AddRange(new object[] {
             "ltr",
             "rtl",
-            "tb-rl"});
+            "ttb-rtl",
+            "ttb-ltr"});
             this.textDirectionComboBox.Location = new System.Drawing.Point(93, 132);
             this.textDirectionComboBox.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
             this.textDirectionComboBox.Name = "textDirectionComboBox";
@@ -3276,7 +3480,7 @@
         private System.Windows.Forms.Label numberSystemLabel;
         private System.Windows.Forms.Label label59;
         private System.Windows.Forms.TextBox ldmlTextBox;
-        private System.Windows.Forms.TextBox scriptTextBox;
+        private System.Windows.Forms.ComboBox scriptComboBox;
         private System.Windows.Forms.Label label61;
         private System.Windows.Forms.Label label63;
         private System.Windows.Forms.TextBox facebookTextBox;

--- a/haiola/haiola.cs
+++ b/haiola/haiola.cs
@@ -2765,8 +2765,10 @@ their generosity, people like you can open up the Bible and hear from God no mat
                                             rodCodeTextBox.Text = MetadataText();
                                         break;
                                     case "language/script":
-                                        if (Utils.IsEmpty(scriptTextBox.Text))
-                                            scriptTextBox.Text = MetadataText();
+                                        if (MetadataText() == String.Empty)
+                                            scriptComboBox.Text = "Latn-Latin";
+                                        else
+                                            scriptComboBox.Text = MetadataText();
                                         break;
                                     case "languge/scriptDirection":
                                         textDirectionComboBox.Text = MetadataText().ToLowerInvariant();
@@ -2957,7 +2959,7 @@ their generosity, people like you can open up the Bible and hear from God no mat
             audioRecordingCopyrightTextBox.Text = globe.projectOptions.AudioCopyrightNotice;
             rodCodeTextBox.Text = globe.projectOptions.rodCode;
             ldmlTextBox.Text = globe.projectOptions.ldml;
-            scriptTextBox.Text = globe.projectOptions.script;
+            scriptComboBox.Text = globe.projectOptions.script;
             localRightsHolderTextBox.Text = globe.projectOptions.localRightsHolder;
             facebookTextBox.Text = globe.projectOptions.facebook;
             countryTextBox.Text = globe.projectOptions.country;
@@ -3268,7 +3270,7 @@ FCBH Dramatized OT: {13}  FCBH Dramatized NT: {14}  FCBH OT: {15}  FCBH NT: {16}
             globe.projectOptions.AudioCopyrightNotice = audioRecordingCopyrightTextBox.Text;
             globe.projectOptions.rodCode = rodCodeTextBox.Text;
             globe.projectOptions.ldml = ldmlTextBox.Text;
-            globe.projectOptions.script = scriptTextBox.Text;
+            globe.projectOptions.script = scriptComboBox.Text;
             globe.projectOptions.localRightsHolder = localRightsHolderTextBox.Text;
             globe.projectOptions.facebook = facebookTextBox.Text;
             globe.projectOptions.country = countryTextBox.Text;

--- a/haiola/haiola.csproj
+++ b/haiola/haiola.csproj
@@ -145,9 +145,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
+  <!-- PropertyGroup>
     <PreBuildEvent>"updateversionsource.exe" "$(ProjectDir)Version.txt" "$(ProjectDir)Version.cs"</PreBuildEvent>
-  </PropertyGroup>
+  </PropertyGroup -->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/haiola/haiolasw.tex
+++ b/haiola/haiolasw.tex
@@ -1,0 +1,299 @@
+\HeaderFont
+\pagestyle{fancy}
+\renewcommand{\headrulewidth}{0pt}
+\fancyhf{}
+\makeatletter
+\renewcommand\tableofcontents{\@starttoc{toc}}
+\makeatother
+\linespread{0.75}
+\sloppy\hyphenpenalty=2000
+\makeatletter
+\def\signdigits#1{\expandafter\@sign@digits #1@}
+\def\@sign@digits#1{%
+  \ifx @#1
+  \else
+    \ifx0#1\char"F2C4F\,\else\ifx1#1\char"F000F\,\else\ifx2#1\char"F054F\,\else\ifx3#1\char"F0B4F\,\else\ifx4#1\char"F198F\,\else\ifx5#1\char"F1C8F\,\else\ifx6#1\char"F32CF\,\else\ifx7#1\char"F3E0F\,\else\ifx8#1\char"F464F\,\else\ifx9#1\char"F4D6F\,\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi
+    \expandafter\@sign@digits
+  \fi
+}
+\makeatother
+\def\signnumber#1{\signdigits{\number#1}}
+\def\signnumeral#1{\signnumber{\csname c@#1\endcsname}}
+\def\signword#1{\raisebox{\FontSize}{\reflectbox{\rotatebox{270}{#1}}}}
+\makeatletter
+\def\signline#1{%
+    \begingroup
+    \edef\@tempa{#1\space}%
+    \expandafter\endgroup
+    \expandafter\readsignwords\@tempa\relax
+}
+\def\readsignwords#1 #2\relax{%
+      \signword{#1}
+      \begingroup
+      \ifx\relax#2\relax
+         \def\next{\endgroup}
+      \else
+         \def\next{\endgroup\readsignwords#2\relax}%
+      \fi
+      \next
+}
+\makeatother
+\renewcommand{\thepage}{\HeaderFont\uccoff\swline\fontsize{\FontSize}{\FontSize}\selectfont\signnumeral{page}\uccon}
+\renewcommand\thesection{}
+\makeatletter
+\renewcommand{\@makefnmark}{\hbox{\raisebox{2pt}{\FnMarkFont{\@thefnmark}}}}
+\makeatother
+\newfontfamily\swfill{\SWFontFill}
+\newfontfamily\swline{\SWFontLine}
+\newcommand{\ParIndent}{1em}
+\newcommand{\IndentA}{2em}
+\newcommand{\IndentB}{3em}
+\newcommand{\IndentC}{4em}
+\newcommand{\IndentD}{5em}
+\newcommand{\IndentE}{6em}
+\newcommand{\ThisFont}{\ScriptureFontFace}
+\newcommand{\GRC}{\renewcommand{\ThisFont}{Gentium Plus}\SetFont}
+\newcommand{\HEB}{\renewcommand{\ThisFont}{Ezra SIL}\SetFont}
+\newcommand{\LatinFont}{\renewcommand{\ThisFont}{FreeSerif}\SetFont}
+\newcommand{\ChineseFont}{\renewcommand{\ThisFont}{Bitstream Cyberbit}\SetFont}
+\newcommand{\GentiumFont}{\renewcommand{\ThisFont}{Gentium Plus}\SetFont}
+\newcommand{\SymbolFont}{\renewcommand{\ThisFont}{FreeSerif}\SetFont}
+\newcommand{\Bold}{}
+\newcommand{\Italicize}{}
+\newcommand{\FontSize}{\TextSize}
+\newcommand{\FontColor}{\TextColor}
+\newcommand{\SMCP}{-smcp}
+\newcommand{\SmallCaps}{\renewcommand{\SMCP}{,+smcp}}
+\newcommand{\NormalCaps}{\renewcommand{\SMCP}{,-smcp}}
+\newcommand{\SetFont}{\font\Z="\ThisFont\Bold\Italicize \FontColor\SMCP" at \FontSize \Z }
+\newcommand{\ITB}{\renewcommand{\Italicize}{/I}\SetFont}
+\newcommand{\ITE}{\renewcommand{\Italicize}{}\SetFont}
+\newcommand{\BDB}{\renewcommand{\Bold}{/B}\SetFont}
+\newcommand{\BDE}{\renewcommand{\Bold}{}\SetFont}
+\newcommand{\Red}{\renewcommand{\FontColor}{\WJColor}\SetFont}
+\newcommand{\Black}{\renewcommand{\FontColor}{\TextColor}\SetFont}
+\newcommand{\Blue}{\renewcommand{\FontColor}{\IntroColor}\SetFont}
+\newcommand{\LightBlue}{\renewcommand{\FontColor}{\BlueColor}\SetFont}
+\newcommand{\Green}{\renewcommand{\FontColor}{\GreenColor}\SetFont}
+\newcommand{\Yellow}{\renewcommand{\FontColor}{\YellowColor}\SetFont}
+\newcommand{\NormalFont}{\renewcommand{\ThisFont}{\ScriptureFontFace}\renewcommand{\Bold}{}\renewcommand{\Italicize}{}\renewcommand{\FontSize}{\TextSize}\Black}
+\NormalFont
+\setDefaultTransitions{\NormalFont}{}
+\setTransitionsForSymbols{\SymbolFont}{}
+\setTransitionsForChinese{\ChineseFont}{}
+\setTransitionsForCJK{\ChineseFont}{}
+\setTransitionsForCyrillics{\GentiumFont}{}
+\setTransitionsForGreek{\GRC}{}
+\setTransitionTo{Arabic}{\NormalFont}
+\setTransitionTo{ArabicExtendedA}{\NormalFont}
+\setTransitionTo{ArabicPresentationFormsA}{\NormalFont}
+\setTransitionTo{ArabicPresentationFormsB}{\NormalFont}
+\setTransitionTo{ArabicSupplement}{\NormalFont}
+\setTransitionTo{ArabicMathematicalAlphabeticSymbols}{\NormalFont}
+\setTransitionTo{Armenian}{\SymbolFont}
+\setTransitionTo{Arrows}{\SymbolFont}
+\setTransitionTo{BasicLatin}{\GentiumFont}
+\setTransitionTo{Coptic}{\renewcommand{\ThisFont}{New Athena Unicode}\SetFont}
+\setTransitionTo{CopticEpactNumbers}{\renewcommand{\ThisFont}{New Athena Unicode}\SetFont}
+\setTransitionTo{Bengali}{\renewcommand{\ThisFont}{Mukti}\SetFont}
+\setTransitionTo{GeneralPunctuation}{\GentiumFont}
+\setTransitionTo{Gujarati}{\renewcommand{\ThisFont}{Rekha}\SetFont}
+\setTransitionTo{Devanagari}{\renewcommand{\ThisFont}{Annapurna SIL}\SetFont}
+\setTransitionTo{Dingbats}{\ITE\SymbolFont}
+\setTransitionTo{Ethiopic}{\renewcommand{\ThisFont}{Abyssinica SIL}\SetFont}
+\setTransitionTo{EthiopicExtended}{\renewcommand{\ThisFont}{Abyssinica SIL}\SetFont}
+\setTransitionTo{EthiopicExtendedA}{\renewcommand{\ThisFont}{Abyssinica SIL}\SetFont}
+\setTransitionTo{EthiopicSupplement}{\renewcommand{\ThisFont}{Abyssinica SIL}\SetFont}
+\setTransitionTo{Hebrew}{\HEB}
+\setTransitionTo{Kannada}{\renewcommand{\ThisFont}{Akshar Unicode}\SetFont}
+\setTransitionTo{Khmer}{\renewcommand{\ThisFont}{Hanuman}\SetFont}
+\setTransitionTo{KhmerSymbols}{\renewcommand{\ThisFont}{Hanuman}\SetFont}
+\setTransitionTo{LatinExtendedA}{\GentiumFont}
+\setTransitionTo{LatinExtendedB}{\GentiumFont}
+\setTransitionTo{LatinExtendedC}{\GentiumFont}
+\setTransitionTo{LatinExtendedD}{\GentiumFont}
+\setTransitionTo{LatinExtendedE}{\GentiumFont}
+\setTransitionTo{LatinSupplement}{\GentiumFont}
+\setTransitionTo{LetterlikeSymbols}{\SymbolFont}
+\setTransitionTo{Limbu}{\renewcommand{\ThisFont}{Namdhinggo SIL}\SetFont}
+\setTransitionTo{MiscellaneousTechnical}{\SymbolFont}
+\setTransitionTo{MiscellaneousSymbols}{\SymbolFont}
+\setTransitionTo{MiscellaneousSymbolsAndArrows}{\SymbolFont}
+\setTransitionTo{MiscellaneousSymbolsAndPictographs}{\SymbolFont}
+\setTransitionTo{Mynmar}{\renewcommand{\ThisFont}{Padauk}\SetFont}
+\setTransitionTo{MynmarExtendedA}{\renewcommand{\ThisFont}{Padauk}\SetFont}
+\setTransitionTo{MynmarExtendedB}{\renewcommand{\ThisFont}{Padauk}\SetFont}
+\setTransitionTo{Syriac}{\renewcommand{\ThisFont}{Estrangelo Edessa}\SetFont}
+\setTransitionTo{Tamil}{\renewcommand{\ThisFont}{Hoonani}\SetFont}
+\setTransitionTo{Telugu}{\renewcommand{\ThisFont}{Akshar Unicode}\SetFont}
+\setTransitionTo{Thai}{\renewcommand{\ThisFont}{Noto Serif Thai}\SetFont}
+\renewcommand{\cfttoctitlefont}{\font\Z="\OtherFontFace:color="000000" at \MTBSize \Z }
+\renewcommand{\cftchapfont}{\font\Z="\OtherFontFace:color="000000" at \TextSize \Z }
+\renewcommand{\cftsecfont}{\font\Z="\OtherFontFace:color="000000" at \TextSize \Z }
+\renewcommand{\cftchappagefont}{\font\Z="\OtherFontFace:color="000000" at \TextSize \Z }
+\renewcommand{\cftsecpagefont}{\font\Z="\OtherFontFace:color="000000" at \TextSize \Z }
+\newcommand{\ShortTitle}[1]{\vfill\eject\clearpage\par\def\webbook{#1}\setcounter{footnote}{0}\def\webchap{}\section[#1]{ }}
+\newcommand{\PeriphTitle}[1]{\vfill\eject\clearpage\par\def\webbook{#1}\setcounter{footnote}{0}\def\webchap{}\markboth{\HeaderFont\webbook}{\HeaderFont\webbook}\NormalFont}
+\newcommand{\PsalmChap}[1]{{\vspace{1.5ex plus 3ex}\centering\renewcommand{\FontSize}{\MTSize}\BDB\parindent=0mm #1\nopagebreak\par}\def\webchap{#1\raisebox{\FontSize}{\char"FF3C3\,}}}
+\newcommand{\PoetryChap}[1]{{\vspace{1.5ex plus 3ex}\centering\renewcommand{\FontSize}{\MTSize}\BDB\parindent=0mm #1\nopagebreak\par}\def\webchap{#1\raisebox{\FontSize}{\char"FF3C3\,}}}
+\newcommand{\Chap}[1]{{\vspace{1.5ex plus 3ex}\centering\renewcommand{\FontSize}{\MTSize}\BDB\parindent=0mm \uccoff\swline\fontsize{\FontSize}{\FontSize}\selectfont#1\uccon\nopagebreak\par}\def\webchap{#1\raisebox{\FontSize}{\char"FF3C3\,}}\nopagebreak}
+\newcommand{\OneChap}{\vspace{1.5ex plus 3ex}\def\webchap{}}
+\newcommand{\ChapOne}[1]{\vspace{1.5ex plus 3ex}\def\webchap{#1\raisebox{\FontSize}{\char"FF3C3\,}}}
+\newcommand{\VS}[1]{{\renewcommand{\FontSize}{\VerseFontSize}\Blue{\raisebox{3\RaiseVerse}{\uccoff\color{blue}\swline\fontsize{\FontSize}{\FontSize}\selectfont#1\uccon}~}}\markboth{\HeaderFont\uccoff\swline\fontsize{\FontSize}{\FontSize}\selectfont\webbook\ \webchap#1\uccon}{\HeaderFont\uccoff\swline\fontsize{\FontSize}{\FontSize}\selectfont\webbook\ \webchap#1\uccon}\NormalFont}	% Verse number
+\newcommand{\VP}[1]{{\renewcommand{\FontSize}{\VerseFontSize}\Blue{\raisebox{\RaiseVerse}{(#1)}~}}\NormalFont}	% Verse number published
+\newcommand{\VA}[1]{{\renewcommand{\FontSize}{\VerseFontSize}\Blue{\raisebox{\RaiseVerse}{[#1]}~}}\NormalFont}	% Alternate verse number
+\newcommand{\FV}[1]{{\renewcommand{\FontSize}{\VerseFontSize}\Blue{\raisebox{\RaiseVerse}{#1}~}}\NormalFont}	% Verse number in footnote
+\newcommand{\FM}{\renewcommand{\FontSize}{\VerseFontSize}\Blue\raisebox{\RaiseVerse}}	% Extra footnote marker
+\newcommand{\VerseOne}[1]{\VS{#1}}
+\newcommand{\PPE}{\par\parindent=\ParIndent}
+\newcommand{\CAPT}{\parindent=0mm\hangindent=0mm\renewcommand{\FontSize}{\FnSize}\Blue}
+\newcommand{\CAPTCOPR}{\parindent=0mm\hangindent=0mm\renewcommand{\FontSize}{6pt}\Blue}
+\newcommand{\CAPTREF}{\parindent=0mm\hangindent=0mm\renewcommand{\FontSize}{\FnSize}\renewcommand{\Italicize}{/I}\Blue}
+\newcommand{\Q}{\vspace{0ex plus 1ex}\par\parindent=0mm\hangafter=1\hangindent=\IndentB\NormalFont}
+\newcommand{\QB}{\par\parindent=\IndentA\hangafter=1\hangindent=\IndentB\NormalFont}
+\newcommand{\QC}{\par\parindent=\IndentC\hangafter=1\hangindent=\IndentD\NormalFont}
+\newcommand{\QD}{\par\parindent=\IndentD\hangafter=1\hangindent=\IndentE\NormalFont}
+\newcommand{\QM}{\vspace{0ex plus 1ex}\par\parindent=\ParIndent\hangafter=1\hangindent=\IndentC\NormalFont}
+\newcommand{\QMB}{\par\parindent=\IndentB\hangafter=1\hangindent=\IndentC\NormalFont}
+\newcommand{\QMC}{\par\parindent=\IndentD\hangafter=1\hangindent=\IndentD\NormalFont}
+\newcommand{\PB}{\vfill\eject\clearpage}
+\newcommand{\PP}{\vspace{0ex plus 1ex}\parindent=\ParIndent\Black}
+\newcommand{\MM}{\parindent=0mm\Black}
+\newcommand{\D}{\parindent=0mm\NormalFont\nopagebreak[3]}
+\newcommand{\MI}{\parindent=\ParIndent\hangafter=1\hangindent=\ParIndent\Black}
+\newcommand{\IMI}{\parindent=\ParIndent\hangafter=1\hangindent=\ParIndent\Blue}
+\newcommand{\PC}{\parindent=0mm\centering\Black}
+\newcommand{\QA}{\parindent=0mm\centering\renewcommand{\Italicize}{/I}\Blue}
+\newcommand{\PI}{\parindent=\IndentA\hangafter=1\hangindent=\ParIndent\Black}
+\newcommand{\PIB}{\parindent=\IndentB\hangafter=1\hangindent=\IndentA\Black}
+\newcommand{\PIC}{\parindent=\IndentC\hangafter=1\hangindent=\IndentB\Black}
+\newcommand{\PMO}{\PI}
+\newcommand{\PM}{\PI}
+\newcommand{\PMC}{\PI}
+\newcommand{\PMR}{\Black\raggedleft}
+\newcommand{\PR}{\PMR}
+\newcommand{\QR}{\PMR}
+\newcommand{\CLS}{\PMR}
+\newcommand{\LI}{\parindent=\ParIndent\hangafter=1\hangindent=\IndentA\Black}
+\newcommand{\LIB}{\parindent=\IndentA\hangafter=1\hangindent=\IndentB\Black}
+\newcommand{\LIC}{\parindent=\IndentB\hangafter=1\hangindent=\IndentC\Black}
+\newcommand{\LID}{\parindent=\IndentC\hangafter=1\hangindent=\IndentD\Black}
+\newcommand{\PH}{\LI}
+\newcommand{\PHB}{\LIB}
+\newcommand{\PHC}{\LIC}
+\newcommand{\LBR}{\\}
+\newcommand{\FTST}{}
+\newcommand{\FNSymbol}{*}
+\newcommand{\FTNT}[2]{\renewcommand{\FNSymbol}{{#1}}\footnote{\renewcommand{\ThisFont}{\OtherFontFace}\renewcommand{\FontSize}{\FnSize}\renewcommand{\Bold}{}\renewcommand{\Italicize}{}\Blue #2}}
+\newcommand{\XREF}[2]{\renewcommand{\FNSymbol}{{#1}}\footnote{\renewcommand{\ThisFont}{\OtherFontFace}\renewcommand{\FontSize}{\FnSize}\renewcommand{\Bold}{}\renewcommand{\Italicize}{}\Blue #2}}
+\newcommand{\FT}{\renewcommand{\ThisFont}{\OtherFontFace}\renewcommand{\FontSize}{\FnSize}\renewcommand{\Bold}{}\renewcommand{\Italicize}{}\Blue}
+\renewcommand{\thefootnote}{\FNSymbol}
+\newcommand{\FR}{\BDB}
+\newcommand{\XO}{\BDB}
+\newcommand{\WJ}{\Red}
+\newcommand{\ZCR}{\Red}
+\newcommand{\ZCG}{\Green}
+\newcommand{\ZCB}{\LightBlue}
+\newcommand{\ZCY}{\Yellow}
+\newcommand{\PsalmBookTitle}[1]{\goodbreak\bigskip{\Large\hangindent=0mm\parindent=0mm\textsf #1}\nobreak\nopagebreak[3]}
+\newcommand{\PsalmTitle}[1]{\nopagebreak{\medskip\hangindent=0mm\parindent=5mm #1\nobreak\par\nobreak\medskip\nopagebreak[3]}}
+\newcommand{\Speaker}[1]{#1}
+\newcommand{\MT}{\renewcommand{\FontSize}{\MTSize}\renewcommand{\Bold}{/B}\Black\parindent=0mm\centering\nopagebreak[3]}
+\newcommand{\MTB}{\renewcommand{\FontSize}{\MTBSize}\renewcommand{\Bold}{/B}\Black\parindent=0mm\centering\nopagebreak[3]}
+\newcommand{\MTC}{\renewcommand{\FontSize}{\MTCSize}\renewcommand{\Bold}{/B}\Black\parindent=0mm\centering\nopagebreak[3]}
+\newcommand{\MTD}{\MTC}
+\newcommand{\MTE}{\MT}
+\newcommand{\MTEB}{\MTB}
+\newcommand{\MTEC}{\MTC}
+\newcommand{\IMT}{\renewcommand{\FontSize}{\MTSize}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering\nopagebreak[3]}
+\newcommand{\IMTB}{\renewcommand{\FontSize}{\MTBSize}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering\nopagebreak[3]}
+\newcommand{\IMTC}{\renewcommand{\FontSize}{\MTCSize}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering\nopagebreak[3]}
+\newcommand{\IMTD}{\renewcommand{\FontSize}{\MTDSize}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering\nopagebreak[3]}
+\newcommand{\MR}{\renewcommand{\FontColor}{\IntroColor}\ITB}
+\newcommand{\SR}{\MR\nopagebreak[4]}
+\newcommand{\R}{\MR\nopagebreak[4]}
+\newcommand{\MS}{\renewcommand{\FontSize}{\MTBSize}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering}
+\newcommand{\MSB}{\renewcommand{\FontSize}{\MTCSize}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering}
+\newcommand{\MSC}{\renewcommand{\FontSize}{\MTCSize}\renewcommand{\Bold}{}\Blue\parindent=0mm\centering}
+\newcommand{\BB}{\NormalFont\vspace{2ex}}
+\newcommand{\IB}{\Blue}
+\newcommand{\QS}{\hfill }
+\newcommand{\SP}{\parindent=0mm\Blue\ITB\nopagebreak[3] }
+\newcommand{\SH}{\vspace{1ex plus 4ex}\renewcommand{\FontColor}{\IntroColor}\ITB\nopagebreak[4]}
+\newcommand{\SHB}{\vspace{1ex plus 4ex}\renewcommand{\FontColor}{\IntroColor}\ITB\nopagebreak[3]}
+\newcommand{\SHC}{\SHB\nopagebreak[3]}
+\newcommand{\SHD}{\SHB\nopagebreak[3]}
+\newcommand{\IS}{\SH}
+\newcommand{\ISB}{\SH}
+\newcommand{\ISC}{\SH}
+\newcommand{\ISD}{\SH}
+\newcommand{\IP}{\vspace{0ex plus 1ex}\parindent=\ParIndent\Blue}
+\newcommand{\IPI}{\parindent=\IndentA\hangafter=1\hangindent=\ParIndent\Blue}
+\newcommand{\IPQ}{\parindent=\IndentA\hangindent=\ParIndent\Blue}
+\newcommand{\IM}{\parindent=0mm\Blue}
+\newcommand{\IMQ}{\parindent=\ParIndent\hangindent=\ParIndent\Blue}
+\newcommand{\TINY}{\parindent=0mm\renewcommand{\ThisFont}{\OtherFontFace}\renewcommand{\FontSize}{\TinyFontSize}\Blue}
+\newcommand{\TINYLI}{\parindent=\ParIndent\hangafter=1\hangindent=\IndentA\renewcommand{\ThisFont}{\OtherFontFace}\renewcommand{\FontSize}{\TinyFontSize}\Blue}
+\newcommand{\TINYIMT}{\renewcommand{\FontSize}{12pt}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering}
+\newcommand{\TINYIMTB}{\renewcommand{\FontSize}{10pt}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering}
+\newcommand{\TINYIMTC}{\renewcommand{\FontSize}{8pt}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering}
+\newcommand{\TINYIMTD}{\renewcommand{\FontSize}{\TinyFontSize}\renewcommand{\Bold}{/B}\Blue\parindent=0mm\centering}
+\newcommand{\IPR}{\Blue\raggedleft}
+\newcommand{\IQ}{\par\parindent=0mm\hangafter=1\hangindent=\IndentB\Blue}
+\newcommand{\IQB}{\par\parindent=\IndentA\hangafter=1\hangindent=\IndentB\Blue}
+\newcommand{\IQC}{\par\parindent=\IndentC\hangafter=1\hangindent=\IndentD\Blue}
+\newcommand{\ILI}{\parindent=\ParIndent\hangindent=\IndentA\Blue}
+\newcommand{\ILIB}{\parindent=\IndentA\hangindent=\IndentB\Blue}
+\newcommand{\ILIC}{\parindent=\IndentB\hangindent=\IndentC\Blue}
+\newcommand{\ILID}{\parindent=\IndentB\hangindent=\IndentD\Blue}
+\newcommand{\IOT}{\parindent=0mm\renewcommand{\FontColor}{\IntroColor}\BDB}
+\newcommand{\IO}{\parindent=\ParIndent\hangindent=\IndentA\Blue}
+\newcommand{\IOB}{\parindent=\IndentA\hangindent=\IndentB\Blue}
+\newcommand{\IOC}{\parindent=\IndentB\hangindent=\IndentC\Blue}
+\newcommand{\IOD}{\parindent=\IndentC\hangindent=\IndentD\Blue}
+\newcommand{\IOR}{\ITB}
+\newcommand{\IEX}{\parindent=\ParIndent\Blue}
+\newcommand{\CD}{\IEX \HeaderFont \IT }
+\newcommand{\IQT}{\ITB}
+\newcommand{\IMTE}{\IMT}
+\newcommand{\IMTEB}{\IMTB}
+\newcommand{\IMTEC}{\IMTC}
+\newcommand{\IE}{\Black}
+\newcommand{\QAC}{\ITB}
+\newcommand{\FK}{\BDB}
+\newcommand{\XK}{\FK}
+\newcommand{\FQ}{\ITB}
+\newcommand{\XQ}{\FQ}
+\newcommand{\XT}{\FT}
+\newcommand{\FQA}{\ITB}
+\newcommand{\FL}{\ITB}
+\newcommand{\FP}{\par}
+\newcommand{\FDC}{}
+\newcommand{\XOT}{}
+\newcommand{\XNT}{}
+\newcommand{\XDC}{}
+\newcommand{\RQ}{\hfill\Blue\ITB}
+\newcommand{\ADD}{\ITB}
+\newcommand{\BK}{\ITB}
+\newcommand{\DC}{}
+\newcommand{\K}[1]{\markboth{\HeaderFont\webbook\ #1}{\HeaderFont\webbook\ #1}\NormalFont\BDB #1}
+\newcommand{\LIT}{\RQ}
+\newcommand{\ND}{\SmallCaps}
+\newcommand{\ORD}[1]{$^#1$}
+\newcommand{\SLS}{\ITB}
+\newcommand{\TL}{\ITB}
+\newcommand{\EM}{\BDB}
+\newcommand{\IT}{\ITB}
+\newcommand{\BDIT}{\BDB\IT}
+\newcommand{\NO}{\NormalFont}
+\newcommand{\SC}{\SmallCaps}
+\newcommand{\PN}{\underline}
+\newcommand{\QT}{\ITB}
+\newcommand{\SIG}{\ITB}
+\newcommand{\BD}{\BDB}
+\newcommand{\NDX}{}
+\newcommand{\PRO}{}
+\newcommand{\W}{}
+\newcommand{\WG}{}
+\newcommand{\WH}{}
+\newcommand{\HR}{\par \hrulefill }

--- a/sepp.sln
+++ b/sepp.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "usfm2usfx", "usfm2usfx\usfm
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "imposis2xml", "imposis2xml\imposis2xml.csproj", "{1E75837A-A555-4C5B-B7FF-A12B37BC937C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fswtotex", "fswtotex\fswtotex.csproj", "{78cca0e2-976f-4bd4-868a-65a996d7974c}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CD_ROM|Any CPU = CD_ROM|Any CPU
@@ -307,6 +309,33 @@ Global
 		{1E75837A-A555-4C5B-B7FF-A12B37BC937C}.SingleImage|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{1E75837A-A555-4C5B-B7FF-A12B37BC937C}.SingleImage|Mixed Platforms.Build.0 = Release|Any CPU
 		{1E75837A-A555-4C5B-B7FF-A12B37BC937C}.SingleImage|x86.ActiveCfg = Release|Any CPU
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.CD_ROM|Any CPU.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.CD_ROM|Mixed Platforms.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.CD_ROM|Mixed Platforms.Build.0 = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.CD_ROM|x86.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.CD_ROM|x86.Build.0 = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Debug|Any CPU.Build.0 = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Debug|x86.ActiveCfg = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Debug|x86.Build.0 = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.DVD-5|Any CPU.ActiveCfg = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.DVD-5|Mixed Platforms.ActiveCfg = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.DVD-5|Mixed Platforms.Build.0 = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.DVD-5|x86.ActiveCfg = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.DVD-5|x86.Build.0 = Debug|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Release|Any CPU.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Release|Any CPU.Build.0 = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Release|Mixed Platforms.Build.0 = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Release|x86.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.Release|x86.Build.0 = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.SingleImage|Any CPU.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.SingleImage|Mixed Platforms.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.SingleImage|Mixed Platforms.Build.0 = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.SingleImage|x86.ActiveCfg = Release|x86
+		{78cca0e2-976f-4bd4-868a-65a996d7974c}.SingleImage|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Addition of new options to publish vertical text (left to right lines) in order to be able to publish an American Sign Language bible in pdf.

No support for html, epub, sword, wordml, nor browser as of yet.
This is pdf support only for now.
Html and browser is hoped for with support of the SWIS (see the wikipedia incubator at https://incubator.wikimedia.org/wiki/Wp/ase/AS10002S1f548M519x514S1f548481x490S10002489x487_AS1f550S15a37S20e00S26502M531x512S15a37501x488S1f550507x495S20e00487x499S26502469x498 as an example).
Other formats have not been looked into yet.

The changes:

Change of text direction "tb-rl" to "ttb-rtl".
Addition of "ttb-rtl".
Changes in haiola_options.cs and haiola.Designer.cs and haiola.cs to support script using the official list of scripts. You can still type whatever you want and current options still load, but having an official list seemed best to me.
Additional checks in Usfx2XeTeX.cs to notice the text direction being ttb-ltr and adjusting some generated files accordingly. Though much of this is still SignWriting specific, I figured having the ability to publish a bible in a first vertical language was more important than making it work for all potential vertical languages.
Additional checks in Usfx2XeTeX.cs to notice the script being "Sgnw-SignWriting" and adjusting accordingly.
Addition of "fswtotex" to the project to support turning a formal SignWriting string (which is what translators would share in usfx) into something that XeLaTeX can show (which is what readers would use).
Addition of "haiolasw.tex" which allows for printing of bibles in SignWriting.

I had to update haiola.csproj to not call updateversionsource because that seems to be missing from this solution. I am not opposed to using this tool, I just don't have it available.
